### PR TITLE
Fix mobile/iOS PWA channel restore and keyboard popup

### DIFF
--- a/web/src/active-buffer.ts
+++ b/web/src/active-buffer.ts
@@ -7,7 +7,7 @@ import { populateMembersForActive } from "./members";
 import { bufferHashFor } from "./router";
 import { prefersNoAutoFocus, setSidebarDrawer } from "./ui-shell";
 
-export type SetActiveOpts = { skipHash?: boolean; replaceHash?: boolean };
+export type SetActiveOpts = { skipHash?: boolean; replaceHash?: boolean; focusInput?: boolean };
 export type SetActive = (id: string, opts?: SetActiveOpts) => void;
 
 export type SetActiveDeps = {
@@ -51,6 +51,10 @@ export function createSetActive(deps: SetActiveDeps): SetActive {
     restoreInputDraft(view.dom.inputEl, id);
     updateInputPopups(view.dom.inputEl, view.dom.cmdPopEl, view.dom.emojiPopEl, view.dom.nickPopEl, activeBuffer());
     deps.maybeMarkActiveRead();
-    if (!prefersNoAutoFocus()) view.dom.inputEl.focus();
+    // Keyboard-driven switches (focusInput) always focus so the user can keep
+    // typing. Pointer-driven switches skip focus on touch devices to avoid
+    // summoning the on-screen keyboard.
+    const shouldFocus = opts.focusInput ?? !prefersNoAutoFocus();
+    if (shouldFocus) view.dom.inputEl.focus();
   };
 }

--- a/web/src/active-buffer.ts
+++ b/web/src/active-buffer.ts
@@ -1,11 +1,11 @@
-import { activeBuffer, state } from "./app-state";
+import { activeBuffer, saveLastActive, state } from "./app-state";
 import type { AppView } from "./app-view";
 import type { DomRefs } from "./dom";
 import { updateInputPopups } from "./input";
 import { restoreInputDraft, saveInputDraft } from "./input-history";
 import { populateMembersForActive } from "./members";
 import { bufferHashFor } from "./router";
-import { setSidebarDrawer } from "./ui-shell";
+import { prefersNoAutoFocus, setSidebarDrawer } from "./ui-shell";
 
 export type SetActiveOpts = { skipHash?: boolean; replaceHash?: boolean };
 export type SetActive = (id: string, opts?: SetActiveOpts) => void;
@@ -21,6 +21,7 @@ export function createSetActive(deps: SetActiveDeps): SetActive {
     const dom = deps.getDom();
     if (dom && state.activeId !== null) saveInputDraft(state.activeId, dom.inputEl.value, true);
     state.activeId = id;
+    saveLastActive(id);
     state.channelList = null;
     setSidebarDrawer(false);
     if (!opts.skipHash) {
@@ -50,6 +51,6 @@ export function createSetActive(deps: SetActiveDeps): SetActive {
     restoreInputDraft(view.dom.inputEl, id);
     updateInputPopups(view.dom.inputEl, view.dom.cmdPopEl, view.dom.emojiPopEl, view.dom.nickPopEl, activeBuffer());
     deps.maybeMarkActiveRead();
-    view.dom.inputEl.focus();
+    if (!prefersNoAutoFocus()) view.dom.inputEl.focus();
   };
 }

--- a/web/src/app-core.ts
+++ b/web/src/app-core.ts
@@ -75,7 +75,7 @@ export function start() {
   document.getElementById("settings-btn")?.addEventListener("click", () => openSettingsDialog());
   document.addEventListener("click", onBackdropClick);
   initTouchGestures({ sidebarEl: d.sidebarEl });
-  initKeyboardShortcuts({ inputEl: d.inputEl, setActive: (id: string) => setActive(id) });
+  initKeyboardShortcuts({ inputEl: d.inputEl, setActive: (id: string) => setActive(id, { focusInput: true }) });
   const onHash = () => onHashChange(setActive);
   window.addEventListener("hashchange", onHash);
   window.addEventListener("popstate", onHash);

--- a/web/src/app-state.ts
+++ b/web/src/app-state.ts
@@ -148,6 +148,24 @@ export function saveLayout(layout: LayoutSettings) {
   }
 }
 
+const LAST_ACTIVE_KEY = "lurker.lastActive";
+
+export function loadLastActive(): string | null {
+  try {
+    return localStorage.getItem(LAST_ACTIVE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function saveLastActive(id: string) {
+  try {
+    localStorage.setItem(LAST_ACTIVE_KEY, id);
+  } catch {
+    // Best-effort; ignore unavailable storage/quota failures.
+  }
+}
+
 export const state: AppState = {
   networks: new Map(),
   buffers: new Map(),

--- a/web/src/connection.ts
+++ b/web/src/connection.ts
@@ -1,4 +1,5 @@
 import {
+  loadLastActive,
   type Member,
   type Message,
   type StateResponse,
@@ -103,10 +104,14 @@ export async function syncStateFromServer(deps: StateSyncDeps) {
   deps.renderMembers();
   if (!state.activeId && state.buffers.size > 0) {
     const fromUrl = deps.bufferFromHash(location.hash);
+    // iOS standalone PWAs cold-launch at the manifest start_url ("/") with no
+    // hash, so fall back to the last active buffer persisted in localStorage.
+    const lastId = loadLastActive();
+    const lastActive = lastId ? state.buffers.get(lastId) : null;
     const firstChannel = [...state.buffers.values()].find(
       (buffer) => buffer.kind === "channel" && buffer.joined === true,
     );
-    const initial = fromUrl ?? firstChannel ?? state.buffers.values().next().value;
+    const initial = fromUrl ?? lastActive ?? firstChannel ?? state.buffers.values().next().value;
     if (initial) deps.setActive(initial.id, { replaceHash: true });
   }
 }

--- a/web/src/keyboard-routing.ts
+++ b/web/src/keyboard-routing.ts
@@ -13,6 +13,8 @@ import { setDesktopSidebarHidden, setMembersDrawer, setSidebarDrawer, toggleSide
 
 export type KeyboardShortcutsDeps = {
   inputEl: HTMLInputElement;
+  // Keyboard-driven buffer switches focus the input so typing continues
+  // uninterrupted, even on touch devices with a hardware keyboard (e.g. iPad).
   setActive: (id: string) => void;
 };
 

--- a/web/src/ui-shell.ts
+++ b/web/src/ui-shell.ts
@@ -2,6 +2,13 @@ export function isMobileViewport(): boolean {
   return window.matchMedia("(max-width: 640px)").matches;
 }
 
+// Touch devices summon an on-screen keyboard when an input is focused, which
+// covers much of the screen. Skip automatic focus there (e.g. switching channels);
+// deliberate focus (tapping the input) still works.
+export function prefersNoAutoFocus(): boolean {
+  return window.matchMedia("(pointer: coarse)").matches;
+}
+
 export function setSidebarDrawer(open: boolean) {
   if (open) document.body.dataset.sidebarOpen = "true";
   else delete document.body.dataset.sidebarOpen;

--- a/web/tests/active-buffer.test.ts
+++ b/web/tests/active-buffer.test.ts
@@ -129,6 +129,25 @@ describe("createSetActive", () => {
     matchMediaSpy.mockRestore();
   });
 
+  it("focuses input on keyboard-driven switches even on touch devices", () => {
+    const dom = makeDom();
+    const view = makeView(dom);
+    const setActive = createSetActive({
+      getDom: () => dom,
+      getView: () => view,
+      maybeMarkActiveRead: vi.fn(),
+    });
+    seedBuffer("b1");
+    const focusSpy = vi.spyOn(dom.inputEl, "focus");
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((q: string) => ({ matches: q === "(pointer: coarse)" }) as MediaQueryList);
+
+    setActive("b1", { focusInput: true });
+    expect(focusSpy).toHaveBeenCalled();
+    matchMediaSpy.mockRestore();
+  });
+
   it("clears channelList state", () => {
     const dom = makeDom();
     const view = makeView(dom);

--- a/web/tests/active-buffer.test.ts
+++ b/web/tests/active-buffer.test.ts
@@ -57,10 +57,12 @@ describe("createSetActive", () => {
   let originalHash: string;
   beforeEach(() => {
     resetAppState();
+    localStorage.clear();
     originalHash = location.hash;
   });
   afterEach(() => {
     resetAppState();
+    localStorage.clear();
     history.replaceState(null, "", `${location.pathname}${originalHash}`);
   });
 
@@ -81,6 +83,7 @@ describe("createSetActive", () => {
     const markRead = vi.fn();
     const setActive = createSetActive({ getDom: () => dom, getView: () => view, maybeMarkActiveRead: markRead });
     seedBuffer("b1");
+    const focusSpy = vi.spyOn(dom.inputEl, "focus");
 
     setActive("b1");
     expect(state.activeId).toBe("b1");
@@ -90,6 +93,40 @@ describe("createSetActive", () => {
     expect(view.renderMembers).toHaveBeenCalled();
     expect(view.updateInputEnabled).toHaveBeenCalled();
     expect(markRead).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("persists the active buffer to localStorage", () => {
+    const dom = makeDom();
+    const view = makeView(dom);
+    const setActive = createSetActive({
+      getDom: () => dom,
+      getView: () => view,
+      maybeMarkActiveRead: vi.fn(),
+    });
+    seedBuffer("b1");
+
+    setActive("b1");
+    expect(localStorage.getItem("lurker.lastActive")).toBe("b1");
+  });
+
+  it("does not auto-focus input on coarse-pointer (touch) devices", () => {
+    const dom = makeDom();
+    const view = makeView(dom);
+    const setActive = createSetActive({
+      getDom: () => dom,
+      getView: () => view,
+      maybeMarkActiveRead: vi.fn(),
+    });
+    seedBuffer("b1");
+    const focusSpy = vi.spyOn(dom.inputEl, "focus");
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((q: string) => ({ matches: q === "(pointer: coarse)" }) as MediaQueryList);
+
+    setActive("b1");
+    expect(focusSpy).not.toHaveBeenCalled();
+    matchMediaSpy.mockRestore();
   });
 
   it("clears channelList state", () => {

--- a/web/tests/connection.test.ts
+++ b/web/tests/connection.test.ts
@@ -91,8 +91,40 @@ describe("connection recovery", () => {
 
   afterEach(() => {
     resetAppState();
+    localStorage.clear();
     vi.unstubAllGlobals();
     vi.useRealTimers();
+  });
+
+  it("restores the last active buffer from localStorage over the first channel when the hash misses", async () => {
+    // Return two joined channels; "10" would be the default first-channel pick.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        if (String(input) === "/api/state") {
+          return Promise.resolve(
+            Response.json({
+              current_nick: "tester",
+              networks: [{ id: "1", name: "Libera", status: "connected" }],
+              buffers: [
+                { id: "10", network_id: "1", name: "#go", kind: "channel", joined: true },
+                { id: "20", network_id: "1", name: "#rust", kind: "channel", joined: true },
+              ],
+              initial_messages: {},
+              members: {},
+            }),
+          );
+        }
+        return Promise.resolve(new Response("{}", { status: 500 }));
+      }),
+    );
+    localStorage.setItem("lurker.lastActive", "20");
+    const d = deps();
+    d.bufferFromHash.mockReturnValue(null);
+
+    await syncStateFromServer(d);
+
+    expect(d.setActive).toHaveBeenCalledWith("20", { replaceHash: true });
   });
 
   it("closes and immediately reconnects a stale websocket that still appears open", () => {


### PR DESCRIPTION
When launched as a standalone PWA on iOS, the app cold-launches at the
manifest start_url ("/") with no URL hash, so active-buffer restoration
(which relied solely on location.hash) always fell back to the first
joined channel. Persist the last active buffer to localStorage and use
it as a fallback when the hash misses.

Also stop auto-focusing the message input on coarse-pointer (touch)
devices when switching channels, which summoned the on-screen keyboard
and covered half the screen. Deliberate focus (tapping the input,
upload, keyboard nav) is unchanged.