### PR TITLE
Inline Bluesky reply parent context instead of raw at:// URI

### DIFF
--- a/ai-docs/datasource-bluesky.md
+++ b/ai-docs/datasource-bluesky.md
@@ -19,14 +19,14 @@ For the cross-cutting `DataSource` abstraction shared by all non-IRC sources, se
 | Notifications (`app.bsky.notification.listNotifications`) | One channel buffer named `#notifications`. |
 | Saved/list feed (`app.bsky.feed.getListFeed`, `app.bsky.feed.getFeed`) | Optional channel buffer per configured feed/list URI, named `#feed:<short-name>`. |
 | Post (`app.bsky.feed.defs#feedViewPost`) | One row via `datasource.IngestPost` → `db.InsertLogMessage` + `MessageEvent`. |
-| `post.author.handle` | `MessageEvent.Sender`. |
-| `post.author.did` | `MessageEvent.Account`. |
-| `record.text` (+ extracted embed URLs joined with space) | `MessageEvent.Content`. |
+| `post.author.displayName` (falls back to `post.author.handle`) | `MessageEvent.Sender`. The display name reads better than the raw handle; the handle is the fallback when no display name is set. |
+| `post.author.did` | `MessageEvent.Account` (stable identifier, unaffected by the display-name label). |
+| `record.text` (+ embed render tokens joined with space) | `MessageEvent.Content`. See [Embeds](#embeds). |
 | `post.uri` | `MessageEvent.MsgID` / `datasource.Post.ExternalID` (dedupe key). |
 | `post.indexedAt` | `MessageEvent.TS`. |
-| Reposts | Sender is original `post.author.handle`; `Content` is prefixed with `[RT by <reposter>] `. |
-| Replies | Top-level only in `#home`. Append an inline parent snippet `(re: @<handle>: "<text…>")` so the replied-to context is visible at a glance; falls back to the raw `at://` URI when the parent cannot be resolved. Do not render a thread tree in MVP. |
-| Quote posts | Append an inline snippet of the quoted post `(quoting @<handle>: "<text…>")`. The quoted record is always embedded in the timeline view (`embed.record`), so no extra fetch is needed. |
+| Reposts | Sender is the original author's display name/handle; `Content` is prefixed with `[RT by <reposter>] ` (reposter display name/handle). |
+| Replies | Top-level only in `#home`. Append an inline parent snippet `(re: <name>: "<text…>")` so the replied-to context is visible at a glance; falls back to the raw `at://` URI when the parent cannot be resolved. Do not render a thread tree in MVP. |
+| Quote posts | Append an inline snippet of the quoted post `(quoting <name>: "<text…>")`. The quoted record is always embedded in the timeline view (`embed.record`), so no extra fetch is needed. |
 
 `MessageEvent.Kind` is set to `"privmsg"` for posts. Status/system messages such as auth failure, rate limiting, or repeated refresh failure go to the status buffer with `Kind="notice"`.
 
@@ -112,6 +112,27 @@ replies and subsequent polls. The cache is owned by the single channel
 goroutine and is not safe for concurrent use. Snippet text is whitespace-
 collapsed and truncated to ~100 runes with an ellipsis.
 
+## Embeds
+
+`renderEmbed` turns a post's `embed` into the tokens appended to its text. It
+emits the previewable URLs (so the shared preview pipeline can attach cards and
+images) interleaved with the human context ATProto already ships for free — no
+extra requests:
+
+- **External cards** — the link URL plus the card `title` in quotes, so the
+  reader sees what a link is even before (or without) the OG preview resolving.
+- **Images** — the `fullsize` (or `thumb`) URL plus the image `alt` text as
+  `[image: <alt>]` when present.
+- **Video** (`app.bsky.embed.video#view`) — the poster `thumbnail` URL plus
+  `[video: <alt>]` (or a bare `[video]` marker). Without this, video posts
+  surfaced as text-only with no indication a video existed.
+- **Record-with-media** (`recordWithMedia#view`) — the media half is walked
+  recursively via `embed.media`; the quoted record half is handled by
+  `quotedPost` (see [Quote posts](#quote-posts)).
+
+Alt text and titles are whitespace-collapsed (newlines flattened) so a token
+stays on one line. Non-post embed union members are skipped.
+
 ## Quote posts
 
 A quote post embeds the quoted record directly in the timeline view, so unlike
@@ -121,9 +142,9 @@ reply parents it needs **no extra request**. The embed shape depends on `$type`:
   (`author`, `value.text`).
 - `app.bsky.embed.recordWithMedia#view` — `embed.record` wraps the `viewRecord`
   one level deeper, and `embed.media` carries the images/external card (already
-  walked by the URL collector). The quote extractor unwraps the nesting.
+  walked by `renderEmbed`). The quote extractor unwraps the nesting.
 
-The quoted post renders inline as `(quoting @<handle>: "<text…>")`, using the
+The quoted post renders inline as `(quoting <name>: "<text…>")`, using the
 same whitespace-collapse/truncation as reply snippets. Non-post union members
 (`viewNotFound`, `viewBlocked`, `viewDetached`, feed generators, lists, starter
 packs) decode with empty author/value and are skipped.

--- a/ai-docs/datasource-bluesky.md
+++ b/ai-docs/datasource-bluesky.md
@@ -25,7 +25,7 @@ For the cross-cutting `DataSource` abstraction shared by all non-IRC sources, se
 | `post.uri` | `MessageEvent.MsgID` / `datasource.Post.ExternalID` (dedupe key). |
 | `post.indexedAt` | `MessageEvent.TS`. |
 | Reposts | Sender is original `post.author.handle`; `Content` is prefixed with `[RT by <reposter>] `. |
-| Replies | Top-level only in `#home`. Append a parent post link when available; do not render a thread tree in MVP. |
+| Replies | Top-level only in `#home`. Append an inline parent snippet `(re: @<handle>: "<text…>")` so the replied-to context is visible at a glance; falls back to the raw `at://` URI when the parent cannot be resolved. Do not render a thread tree in MVP. |
 
 `MessageEvent.Kind` is set to `"privmsg"` for posts. Status/system messages such as auth failure, rate limiting, or repeated refresh failure go to the status buffer with `Kind="notice"`.
 
@@ -86,6 +86,30 @@ Restart behavior:
 - On restart, fetch newest page for each configured channel.
 - Existing messages are ignored by `(buffer_id, msgid)` dedupe.
 - New messages missed while offline are ingested if still present in the newest page. Deep gap-fill/backfill is deferred.
+
+## Reply parent resolution
+
+Replies carry their parent post's `at://` URI in `record.reply.parent`. To make
+the buffer readable without clicking out of the app, each reply inlines a short
+parent snippet instead of the bare URI.
+
+Resolution is per-poll and best-effort, in priority order:
+
+1. **Inline feed context (free)** — `app.bsky.feed.getTimeline` already embeds
+   the full parent `PostView` under `feedViewPost.reply.parent` when it is
+   visible. Use it directly; no extra request. `notFound`/`blocked` parents
+   decode to a stub with only `uri` set and are skipped.
+2. **Batched hydration** — remaining parent URIs are fetched via
+   `app.bsky.feed.getPosts` (max 25 URIs/call, so chunk). Missing/blocked posts
+   are simply absent from the response.
+3. **Fallback** — anything still unresolved renders as the raw `at://` URI, so
+   context is never silently dropped.
+
+Resolved parents are held in a small per-channel FIFO cache (~500 entries,
+keyed by parent URI) so a parent is hydrated once and reused across sibling
+replies and subsequent polls. The cache is owned by the single channel
+goroutine and is not safe for concurrent use. Snippet text is whitespace-
+collapsed and truncated to ~100 runes with an ellipsis.
 
 ## Configuration
 

--- a/ai-docs/datasource-bluesky.md
+++ b/ai-docs/datasource-bluesky.md
@@ -26,6 +26,7 @@ For the cross-cutting `DataSource` abstraction shared by all non-IRC sources, se
 | `post.indexedAt` | `MessageEvent.TS`. |
 | Reposts | Sender is original `post.author.handle`; `Content` is prefixed with `[RT by <reposter>] `. |
 | Replies | Top-level only in `#home`. Append an inline parent snippet `(re: @<handle>: "<text…>")` so the replied-to context is visible at a glance; falls back to the raw `at://` URI when the parent cannot be resolved. Do not render a thread tree in MVP. |
+| Quote posts | Append an inline snippet of the quoted post `(quoting @<handle>: "<text…>")`. The quoted record is always embedded in the timeline view (`embed.record`), so no extra fetch is needed. |
 
 `MessageEvent.Kind` is set to `"privmsg"` for posts. Status/system messages such as auth failure, rate limiting, or repeated refresh failure go to the status buffer with `Kind="notice"`.
 
@@ -110,6 +111,22 @@ keyed by parent URI) so a parent is hydrated once and reused across sibling
 replies and subsequent polls. The cache is owned by the single channel
 goroutine and is not safe for concurrent use. Snippet text is whitespace-
 collapsed and truncated to ~100 runes with an ellipsis.
+
+## Quote posts
+
+A quote post embeds the quoted record directly in the timeline view, so unlike
+reply parents it needs **no extra request**. The embed shape depends on `$type`:
+
+- `app.bsky.embed.record#view` — `embed.record` is the quoted `viewRecord`
+  (`author`, `value.text`).
+- `app.bsky.embed.recordWithMedia#view` — `embed.record` wraps the `viewRecord`
+  one level deeper, and `embed.media` carries the images/external card (already
+  walked by the URL collector). The quote extractor unwraps the nesting.
+
+The quoted post renders inline as `(quoting @<handle>: "<text…>")`, using the
+same whitespace-collapse/truncation as reply snippets. Non-post union members
+(`viewNotFound`, `viewBlocked`, `viewDetached`, feed generators, lists, starter
+packs) decode with empty author/value and are skipped.
 
 ## Configuration
 

--- a/datasource/bluesky/client.go
+++ b/datasource/bluesky/client.go
@@ -138,6 +138,34 @@ func (c *Client) GetTimeline(ctx context.Context, limit int, cursor string) (*Fe
 	return &out, nil
 }
 
+// getPostsMax is the per-call URI cap of app.bsky.feed.getPosts. Callers
+// must chunk longer lists.
+const getPostsMax = 25
+
+// GetPosts hydrates posts by their at:// URIs via app.bsky.feed.getPosts.
+// At most getPostsMax URIs are honoured per call; extras are dropped by the
+// API, so callers chunk. Missing/blocked posts are simply absent from the
+// response rather than erroring.
+func (c *Client) GetPosts(ctx context.Context, uris []string) ([]PostView, error) {
+	if len(uris) == 0 {
+		return nil, nil
+	}
+	if len(uris) > getPostsMax {
+		uris = uris[:getPostsMax]
+	}
+	q := url.Values{}
+	for _, u := range uris {
+		q.Add("uris", u)
+	}
+	var out struct {
+		Posts []PostView `json:"posts"`
+	}
+	if err := c.callAuthed(ctx, http.MethodGet, "app.bsky.feed.getPosts", q, nil, &out); err != nil {
+		return nil, fmt.Errorf("getPosts: %w", err)
+	}
+	return out.Posts, nil
+}
+
 // callAuthed runs an authenticated XRPC call. On expired access JWT it
 // refreshes and retries once; if the refresh JWT itself is expired it
 // re-runs createSession and retries once.

--- a/datasource/bluesky/source.go
+++ b/datasource/bluesky/source.go
@@ -177,12 +177,13 @@ func (s *Source) resolveChannels(parent context.Context, deps datasource.Deps, n
 
 func (s *Source) runChannel(ctx context.Context, deps datasource.Deps, rc runtimeChannel) {
 	lru := newURILRU(500)
+	parents := newParentCache(500)
 
 	// Initial fetch is immediate; subsequent fetches run on the channel
 	// interval. backoff doubles up to ~10 min on repeated failure.
 	backoff := time.Second
 	for {
-		if err := s.pollOnce(ctx, deps, rc, lru); err != nil {
+		if err := s.pollOnce(ctx, deps, rc, lru, parents); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return
 			}
@@ -204,7 +205,7 @@ func (s *Source) runChannel(ctx context.Context, deps datasource.Deps, rc runtim
 	}
 }
 
-func (s *Source) pollOnce(ctx context.Context, deps datasource.Deps, rc runtimeChannel, lru *uriLRU) error {
+func (s *Source) pollOnce(ctx context.Context, deps datasource.Deps, rc runtimeChannel, lru *uriLRU, parents *parentCache) error {
 	page, err := s.fetchPage(ctx, rc.cfg)
 	if err != nil {
 		return err
@@ -218,21 +219,69 @@ func (s *Source) pollOnce(ctx context.Context, deps datasource.Deps, rc runtimeC
 	sort.Slice(page.Feed, func(i, j int) bool {
 		return page.Feed[i].Post.IndexedAt < page.Feed[j].Post.IndexedAt
 	})
+
+	// Keep only items we will actually ingest, so we resolve reply parents
+	// for fresh posts only.
+	fresh := make([]FeedItem, 0, len(page.Feed))
 	for _, item := range page.Feed {
 		uri := item.Post.URI
+		if uri == "" || lru.seen(uri) {
+			continue
+		}
+		fresh = append(fresh, item)
+	}
+	if len(fresh) == 0 {
+		return nil
+	}
+
+	s.resolveParents(ctx, fresh, parents)
+
+	for _, item := range fresh {
+		post := mapFeedItem(item, parents.get)
+		if _, _, err := datasource.IngestPost(ctx, deps, s.networkID, rc.bufferID, post); err != nil {
+			slog.Warn("bluesky ingest failed", "uri", item.Post.URI, "err", err)
+			continue
+		}
+		lru.add(item.Post.URI)
+	}
+	return nil
+}
+
+// resolveParents fills the parent cache for every reply in items. It prefers
+// the parent PostView the timeline already embeds (free), and batch-hydrates
+// the rest via getPosts. Resolution is best-effort: on fetch failure the
+// affected replies fall back to rendering the raw parent URI.
+func (s *Source) resolveParents(ctx context.Context, items []FeedItem, parents *parentCache) {
+	var need []string
+	queued := map[string]bool{}
+	for _, item := range items {
+		uri := parentURI(item)
 		if uri == "" {
 			continue
 		}
-		if lru.seen(uri) {
+		if _, ok := parents.get(uri); ok {
 			continue
 		}
-		if _, _, err := datasource.IngestPost(ctx, deps, s.networkID, rc.bufferID, mapFeedItem(item)); err != nil {
-			slog.Warn("bluesky ingest failed", "uri", uri, "err", err)
+		if ref, ok := inlineParent(item, uri); ok {
+			parents.put(uri, ref)
 			continue
 		}
-		lru.add(uri)
+		if !queued[uri] {
+			queued[uri] = true
+			need = append(need, uri)
+		}
 	}
-	return nil
+	for start := 0; start < len(need); start += getPostsMax {
+		end := min(start+getPostsMax, len(need))
+		posts, err := s.client.GetPosts(ctx, need[start:end])
+		if err != nil {
+			slog.Warn("bluesky parent fetch failed", "network", s.cfg.Network, "err", err)
+			return
+		}
+		for _, p := range posts {
+			parents.put(p.URI, parentRef{handle: p.Author.Handle, text: p.Record.Text})
+		}
+	}
 }
 
 func (s *Source) emitStatus(ctx context.Context, deps datasource.Deps, msg string) {
@@ -247,8 +296,20 @@ func (s *Source) emitStatus(ctx context.Context, deps datasource.Deps, msg strin
 	})
 }
 
-// mapFeedItem converts a Bluesky feed item to a datasource.Post.
-func mapFeedItem(item FeedItem) datasource.Post {
+// parentSnippetLen caps the inlined parent-post text so a reply stays
+// glanceable in the buffer.
+const parentSnippetLen = 100
+
+// parentRef is the minimal parent-post context rendered inline on a reply.
+type parentRef struct {
+	handle string
+	text   string
+}
+
+// mapFeedItem converts a Bluesky feed item to a datasource.Post. resolveParent
+// returns the cached parent context for a reply's parent URI; pass nil to fall
+// back to rendering the raw URI.
+func mapFeedItem(item FeedItem, resolveParent func(uri string) (parentRef, bool)) datasource.Post {
 	p := item.Post
 	content := p.Record.Text
 
@@ -267,9 +328,8 @@ func mapFeedItem(item FeedItem) datasource.Post {
 		content = "[RT by " + item.Reason.By.Handle + "] " + content
 	}
 
-	if p.Record.Reply != nil && p.Record.Reply.Parent != nil && p.Record.Reply.Parent.URI != "" {
-		// Best-effort parent reference; thread tree rendering is out of scope.
-		content += " (re: " + p.Record.Reply.Parent.URI + ")"
+	if uri := parentURI(item); uri != "" {
+		content += " " + renderParent(uri, resolveParent)
 	}
 
 	ts := parseATTimestamp(p.IndexedAt)
@@ -281,6 +341,66 @@ func mapFeedItem(item FeedItem) datasource.Post {
 		Kind:      "privmsg",
 		Content:   content,
 	}
+}
+
+// parentURI returns the at:// URI of the post this item replies to, or "".
+func parentURI(item FeedItem) string {
+	r := item.Post.Record.Reply
+	if r == nil || r.Parent == nil {
+		return ""
+	}
+	return r.Parent.URI
+}
+
+// inlineParent extracts the parent context from the timeline's embedded reply
+// PostView when present and hydrated. notFound/blocked parents (only URI set)
+// and URI mismatches return false so the caller falls back to getPosts.
+func inlineParent(item FeedItem, uri string) (parentRef, bool) {
+	if item.Reply == nil || item.Reply.Parent == nil {
+		return parentRef{}, false
+	}
+	pv := item.Reply.Parent
+	if pv.URI != uri {
+		return parentRef{}, false
+	}
+	if pv.Author.Handle == "" && pv.Record.Text == "" {
+		return parentRef{}, false
+	}
+	return parentRef{handle: pv.Author.Handle, text: pv.Record.Text}, true
+}
+
+// renderParent formats the inline reply reference. With a resolved parent it
+// produces e.g. `(re: @alice.bsky.social: "the quoted text…")`; otherwise it
+// falls back to the raw URI so context is never silently dropped.
+func renderParent(uri string, resolve func(uri string) (parentRef, bool)) string {
+	if resolve != nil {
+		if ref, ok := resolve(uri); ok {
+			snippet := truncateSnippet(ref.text, parentSnippetLen)
+			switch {
+			case ref.handle != "" && snippet != "":
+				return "(re: @" + ref.handle + ": \"" + snippet + "\")"
+			case ref.handle != "":
+				return "(re: @" + ref.handle + ")"
+			case snippet != "":
+				return "(re: \"" + snippet + "\")"
+			}
+		}
+	}
+	return "(re: " + uri + ")"
+}
+
+// truncateSnippet collapses whitespace and trims s to at most max runes,
+// appending an ellipsis when it cuts.
+func truncateSnippet(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if max <= 0 {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return strings.TrimRight(string(r[:max]), " ") + "…"
 }
 
 func collectEmbedURLs(e *Embed) []string {
@@ -380,5 +500,52 @@ func (l *uriLRU) add(uri string) {
 		}
 		l.order.Remove(oldest)
 		delete(l.index, oldest.Value.(string))
+	}
+}
+
+// parentCache is a bounded FIFO map from parent URI to its resolved context.
+// It lets a reply's parent be hydrated once and reused across polls and across
+// sibling replies in the same batch. Owned by a single channel goroutine — not
+// safe for concurrent use.
+type parentCache struct {
+	cap   int
+	order *list.List
+	index map[string]*list.Element
+}
+
+type parentEntry struct {
+	uri string
+	ref parentRef
+}
+
+func newParentCache(capacity int) *parentCache {
+	if capacity <= 0 {
+		capacity = 500
+	}
+	return &parentCache{cap: capacity, order: list.New(), index: map[string]*list.Element{}}
+}
+
+func (c *parentCache) get(uri string) (parentRef, bool) {
+	el, ok := c.index[uri]
+	if !ok {
+		return parentRef{}, false
+	}
+	return el.Value.(*parentEntry).ref, true
+}
+
+func (c *parentCache) put(uri string, ref parentRef) {
+	if el, ok := c.index[uri]; ok {
+		el.Value.(*parentEntry).ref = ref
+		return
+	}
+	el := c.order.PushBack(&parentEntry{uri: uri, ref: ref})
+	c.index[uri] = el
+	for c.order.Len() > c.cap {
+		oldest := c.order.Front()
+		if oldest == nil {
+			break
+		}
+		c.order.Remove(oldest)
+		delete(c.index, oldest.Value.(*parentEntry).uri)
 	}
 }

--- a/datasource/bluesky/source.go
+++ b/datasource/bluesky/source.go
@@ -451,18 +451,18 @@ func quotedPost(e *Embed) (parentRef, bool) {
 	return parentRef{}, false
 }
 
-// truncateSnippet collapses whitespace and trims s to at most max runes,
+// truncateSnippet collapses whitespace and trims s to at most limit runes,
 // appending an ellipsis when it cuts.
-func truncateSnippet(s string, max int) string {
+func truncateSnippet(s string, limit int) string {
 	s = oneLine(s)
-	if max <= 0 {
+	if limit <= 0 {
 		return s
 	}
 	r := []rune(s)
-	if len(r) <= max {
+	if len(r) <= limit {
 		return s
 	}
-	return strings.TrimRight(string(r[:max]), " ") + "…"
+	return strings.TrimRight(string(r[:limit]), " ") + "…"
 }
 
 // renderEmbed produces the tokens appended to a post's text for its embed:

--- a/datasource/bluesky/source.go
+++ b/datasource/bluesky/source.go
@@ -332,6 +332,12 @@ func mapFeedItem(item FeedItem, resolveParent func(uri string) (parentRef, bool)
 		content += " " + renderParent(uri, resolveParent)
 	}
 
+	if q, ok := quotedPost(p.Embed); ok {
+		if r := renderQuote(q); r != "" {
+			content += " " + r
+		}
+	}
+
 	ts := parseATTimestamp(p.IndexedAt)
 	return datasource.Post{
 		MsgID:     p.URI,
@@ -387,6 +393,46 @@ func renderParent(uri string, resolve func(uri string) (parentRef, bool)) string
 		}
 	}
 	return "(re: " + uri + ")"
+}
+
+// renderQuote formats the inline quote-post reference, e.g.
+// `(quoting @alice.bsky.social: "the quoted text…")`. Returns "" when there is
+// nothing to show.
+func renderQuote(q parentRef) string {
+	snippet := truncateSnippet(q.text, parentSnippetLen)
+	switch {
+	case q.handle != "" && snippet != "":
+		return "(quoting @" + q.handle + ": \"" + snippet + "\")"
+	case q.handle != "":
+		return "(quoting @" + q.handle + ")"
+	case snippet != "":
+		return "(quoting \"" + snippet + "\")"
+	default:
+		return ""
+	}
+}
+
+// quotedPost extracts the quoted post (handle + text) from an embed, or false
+// when the embed is not a quote or the quoted record is unhydrated. The quoted
+// post is always carried inline by the timeline, so no fetch is needed. Handles
+// both app.bsky.embed.record#view (quote directly under Record) and the record
+// half of recordWithMedia#view (quote nested one level deeper).
+func quotedPost(e *Embed) (parentRef, bool) {
+	if e == nil {
+		return parentRef{}, false
+	}
+	// The loop bound guards against a malformed/cyclic nesting; in practice
+	// recordWithMedia nests at most one level.
+	for rec, i := e.Record, 0; rec != nil && i < 4; rec, i = rec.Record, i+1 {
+		text := ""
+		if rec.Value != nil {
+			text = rec.Value.Text
+		}
+		if rec.Author.Handle != "" || text != "" {
+			return parentRef{handle: rec.Author.Handle, text: text}, true
+		}
+	}
+	return parentRef{}, false
 }
 
 // truncateSnippet collapses whitespace and trims s to at most max runes,

--- a/datasource/bluesky/source.go
+++ b/datasource/bluesky/source.go
@@ -279,7 +279,7 @@ func (s *Source) resolveParents(ctx context.Context, items []FeedItem, parents *
 			return
 		}
 		for _, p := range posts {
-			parents.put(p.URI, parentRef{handle: p.Author.Handle, text: p.Record.Text})
+			parents.put(p.URI, parentRef{name: personLabel(p.Author), text: p.Record.Text})
 		}
 	}
 }
@@ -300,10 +300,25 @@ func (s *Source) emitStatus(ctx context.Context, deps datasource.Deps, msg strin
 // glanceable in the buffer.
 const parentSnippetLen = 100
 
-// parentRef is the minimal parent-post context rendered inline on a reply.
+// parentRef is the minimal parent-post context rendered inline on a reply or
+// quote. name is the display name, falling back to the handle.
 type parentRef struct {
-	handle string
-	text   string
+	name string
+	text string
+}
+
+// personLabel prefers an actor's display name and falls back to the stable
+// handle, so the timeline reads with human names rather than raw handles.
+func personLabel(a Actor) string {
+	if n := strings.TrimSpace(a.DisplayName); n != "" {
+		return n
+	}
+	return a.Handle
+}
+
+// oneLine collapses runs of whitespace (including newlines) to single spaces.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // mapFeedItem converts a Bluesky feed item to a datasource.Post. resolveParent
@@ -313,19 +328,20 @@ func mapFeedItem(item FeedItem, resolveParent func(uri string) (parentRef, bool)
 	p := item.Post
 	content := p.Record.Text
 
-	embedURLs := collectEmbedURLs(p.Embed)
-	if len(embedURLs) > 0 {
+	if parts := renderEmbed(p.Embed); len(parts) > 0 {
 		if content != "" {
 			content += " "
 		}
-		content += strings.Join(embedURLs, " ")
+		content += strings.Join(parts, " ")
 	}
 
-	sender := p.Author.Handle
+	sender := personLabel(p.Author)
 	account := p.Author.DID
 
-	if item.Reason != nil && strings.HasSuffix(item.Reason.Type, "#reasonRepost") && item.Reason.By.Handle != "" {
-		content = "[RT by " + item.Reason.By.Handle + "] " + content
+	if item.Reason != nil && strings.HasSuffix(item.Reason.Type, "#reasonRepost") {
+		if by := personLabel(item.Reason.By); by != "" {
+			content = "[RT by " + by + "] " + content
+		}
 	}
 
 	if uri := parentURI(item); uri != "" {
@@ -372,21 +388,21 @@ func inlineParent(item FeedItem, uri string) (parentRef, bool) {
 	if pv.Author.Handle == "" && pv.Record.Text == "" {
 		return parentRef{}, false
 	}
-	return parentRef{handle: pv.Author.Handle, text: pv.Record.Text}, true
+	return parentRef{name: personLabel(pv.Author), text: pv.Record.Text}, true
 }
 
 // renderParent formats the inline reply reference. With a resolved parent it
-// produces e.g. `(re: @alice.bsky.social: "the quoted text…")`; otherwise it
-// falls back to the raw URI so context is never silently dropped.
+// produces e.g. `(re: Alice: "the quoted text…")`; otherwise it falls back to
+// the raw URI so context is never silently dropped.
 func renderParent(uri string, resolve func(uri string) (parentRef, bool)) string {
 	if resolve != nil {
 		if ref, ok := resolve(uri); ok {
 			snippet := truncateSnippet(ref.text, parentSnippetLen)
 			switch {
-			case ref.handle != "" && snippet != "":
-				return "(re: @" + ref.handle + ": \"" + snippet + "\")"
-			case ref.handle != "":
-				return "(re: @" + ref.handle + ")"
+			case ref.name != "" && snippet != "":
+				return "(re: " + ref.name + ": \"" + snippet + "\")"
+			case ref.name != "":
+				return "(re: " + ref.name + ")"
 			case snippet != "":
 				return "(re: \"" + snippet + "\")"
 			}
@@ -396,15 +412,15 @@ func renderParent(uri string, resolve func(uri string) (parentRef, bool)) string
 }
 
 // renderQuote formats the inline quote-post reference, e.g.
-// `(quoting @alice.bsky.social: "the quoted text…")`. Returns "" when there is
-// nothing to show.
+// `(quoting Alice: "the quoted text…")`. Returns "" when there is nothing to
+// show.
 func renderQuote(q parentRef) string {
 	snippet := truncateSnippet(q.text, parentSnippetLen)
 	switch {
-	case q.handle != "" && snippet != "":
-		return "(quoting @" + q.handle + ": \"" + snippet + "\")"
-	case q.handle != "":
-		return "(quoting @" + q.handle + ")"
+	case q.name != "" && snippet != "":
+		return "(quoting " + q.name + ": \"" + snippet + "\")"
+	case q.name != "":
+		return "(quoting " + q.name + ")"
 	case snippet != "":
 		return "(quoting \"" + snippet + "\")"
 	default:
@@ -429,7 +445,7 @@ func quotedPost(e *Embed) (parentRef, bool) {
 			text = rec.Value.Text
 		}
 		if rec.Author.Handle != "" || text != "" {
-			return parentRef{handle: rec.Author.Handle, text: text}, true
+			return parentRef{name: personLabel(rec.Author), text: text}, true
 		}
 	}
 	return parentRef{}, false
@@ -438,7 +454,7 @@ func quotedPost(e *Embed) (parentRef, bool) {
 // truncateSnippet collapses whitespace and trims s to at most max runes,
 // appending an ellipsis when it cuts.
 func truncateSnippet(s string, max int) string {
-	s = strings.Join(strings.Fields(s), " ")
+	s = oneLine(s)
 	if max <= 0 {
 		return s
 	}
@@ -449,23 +465,50 @@ func truncateSnippet(s string, max int) string {
 	return strings.TrimRight(string(r[:max]), " ") + "…"
 }
 
-func collectEmbedURLs(e *Embed) []string {
+// renderEmbed produces the tokens appended to a post's text for its embed:
+// media URLs (so the preview pipeline can attach cards/images) interleaved
+// with the human context ATProto already ships for free — external card
+// titles, image alt text, and video markers. It recurses into Media for
+// recordWithMedia embeds; the quoted record is handled separately by
+// quotedPost.
+func renderEmbed(e *Embed) []string {
 	if e == nil {
 		return nil
 	}
 	var out []string
+
 	if e.External != nil && e.External.URI != "" {
 		out = append(out, e.External.URI)
-	}
-	for _, img := range e.Images {
-		if img.Fullsize != "" {
-			out = append(out, img.Fullsize)
-		} else if img.Thumb != "" {
-			out = append(out, img.Thumb)
+		if t := oneLine(e.External.Title); t != "" {
+			out = append(out, "\""+t+"\"")
 		}
 	}
+
+	for _, img := range e.Images {
+		switch {
+		case img.Fullsize != "":
+			out = append(out, img.Fullsize)
+		case img.Thumb != "":
+			out = append(out, img.Thumb)
+		}
+		if alt := oneLine(img.Alt); alt != "" {
+			out = append(out, "[image: "+alt+"]")
+		}
+	}
+
+	if e.Thumbnail != "" || e.Playlist != "" {
+		if e.Thumbnail != "" {
+			out = append(out, e.Thumbnail)
+		}
+		if alt := oneLine(e.Alt); alt != "" {
+			out = append(out, "[video: "+alt+"]")
+		} else {
+			out = append(out, "[video]")
+		}
+	}
+
 	if e.Media != nil {
-		out = append(out, collectEmbedURLs(e.Media)...)
+		out = append(out, renderEmbed(e.Media)...)
 	}
 	return out
 }

--- a/datasource/bluesky/source_test.go
+++ b/datasource/bluesky/source_test.go
@@ -14,7 +14,7 @@ func TestMapFeedItemBasic(t *testing.T) {
 			IndexedAt: "2026-05-15T10:00:00Z",
 		},
 	}
-	post := mapFeedItem(item)
+	post := mapFeedItem(item, nil)
 	if post.MsgID != item.Post.URI {
 		t.Fatalf("msgid = %q", post.MsgID)
 	}
@@ -44,7 +44,7 @@ func TestMapFeedItemRepost(t *testing.T) {
 			By:   Actor{Handle: "bob.bsky.social"},
 		},
 	}
-	post := mapFeedItem(item)
+	post := mapFeedItem(item, nil)
 	if !strings.HasPrefix(post.Content, "[RT by bob.bsky.social]") {
 		t.Fatalf("repost prefix missing: %q", post.Content)
 	}
@@ -65,13 +65,13 @@ func TestMapFeedItemExternalEmbed(t *testing.T) {
 			},
 		},
 	}
-	post := mapFeedItem(item)
+	post := mapFeedItem(item, nil)
 	if !strings.Contains(post.Content, "https://example.com/x") {
 		t.Fatalf("embed url missing: %q", post.Content)
 	}
 }
 
-func TestMapFeedItemReplyAppendsParent(t *testing.T) {
+func TestMapFeedItemReplyFallsBackToURI(t *testing.T) {
 	item := FeedItem{
 		Post: PostView{
 			URI:    "at://did:plc:abc/app.bsky.feed.post/3",
@@ -82,9 +82,108 @@ func TestMapFeedItemReplyAppendsParent(t *testing.T) {
 			},
 		},
 	}
-	post := mapFeedItem(item)
-	if !strings.Contains(post.Content, "re: at://did:plc:xyz/app.bsky.feed.post/p") {
+	// nil resolver and an unknown parent both fall back to the raw URI so
+	// context is never silently dropped.
+	post := mapFeedItem(item, nil)
+	if !strings.Contains(post.Content, "(re: at://did:plc:xyz/app.bsky.feed.post/p)") {
 		t.Fatalf("reply parent missing: %q", post.Content)
+	}
+}
+
+func TestMapFeedItemReplyRendersResolvedSnippet(t *testing.T) {
+	parentURI := "at://did:plc:xyz/app.bsky.feed.post/p"
+	item := FeedItem{
+		Post: PostView{
+			URI:    "at://did:plc:abc/app.bsky.feed.post/3",
+			Author: Actor{Handle: "alice.bsky.social"},
+			Record: Record{
+				Text:  "yeah agreed",
+				Reply: &ReplyRef{Parent: &StrongRef{URI: parentURI}},
+			},
+		},
+	}
+	resolve := func(uri string) (parentRef, bool) {
+		if uri != parentURI {
+			return parentRef{}, false
+		}
+		return parentRef{handle: "bob.bsky.social", text: "the original hot take"}, true
+	}
+	post := mapFeedItem(item, resolve)
+	want := "yeah agreed (re: @bob.bsky.social: \"the original hot take\")"
+	if post.Content != want {
+		t.Fatalf("content = %q, want %q", post.Content, want)
+	}
+}
+
+func TestInlineParent(t *testing.T) {
+	uri := "at://did:plc:xyz/app.bsky.feed.post/p"
+	base := func() FeedItem {
+		return FeedItem{
+			Post: PostView{
+				Record: Record{Reply: &ReplyRef{Parent: &StrongRef{URI: uri}}},
+			},
+		}
+	}
+
+	// Hydrated inline parent is used directly.
+	item := base()
+	item.Reply = &FeedReplyRef{Parent: &PostView{
+		URI:    uri,
+		Author: Actor{Handle: "bob.bsky.social"},
+		Record: Record{Text: "hello"},
+	}}
+	if ref, ok := inlineParent(item, uri); !ok || ref.handle != "bob.bsky.social" || ref.text != "hello" {
+		t.Fatalf("inline parent = %+v ok=%v", ref, ok)
+	}
+
+	// notFound/blocked stub (only URI set) is rejected so the caller fetches.
+	stub := base()
+	stub.Reply = &FeedReplyRef{Parent: &PostView{URI: uri}}
+	if _, ok := inlineParent(stub, uri); ok {
+		t.Fatal("expected stub parent to be rejected")
+	}
+
+	// URI mismatch is rejected.
+	mism := base()
+	mism.Reply = &FeedReplyRef{Parent: &PostView{
+		URI:    "at://did:plc:other/app.bsky.feed.post/q",
+		Record: Record{Text: "nope"},
+	}}
+	if _, ok := inlineParent(mism, uri); ok {
+		t.Fatal("expected URI mismatch to be rejected")
+	}
+}
+
+func TestTruncateSnippet(t *testing.T) {
+	if got := truncateSnippet("  hello\n\nworld  ", 100); got != "hello world" {
+		t.Fatalf("collapse = %q", got)
+	}
+	if got := truncateSnippet("abcdefghij", 5); got != "abcde…" {
+		t.Fatalf("truncate = %q", got)
+	}
+	if got := truncateSnippet("abc def ghi", 4); got != "abc…" {
+		t.Fatalf("trailing space trim = %q", got)
+	}
+}
+
+func TestParentCache(t *testing.T) {
+	c := newParentCache(2)
+	c.put("a", parentRef{handle: "ha"})
+	c.put("b", parentRef{handle: "hb"})
+	if ref, ok := c.get("a"); !ok || ref.handle != "ha" {
+		t.Fatalf("get a = %+v ok=%v", ref, ok)
+	}
+	c.put("c", parentRef{handle: "hc"}) // evicts "a"
+	if _, ok := c.get("a"); ok {
+		t.Fatal("a should have been evicted")
+	}
+	if _, ok := c.get("c"); !ok {
+		t.Fatal("c should be present")
+	}
+	// put on existing key updates in place without eviction churn.
+	c.put("b", parentRef{handle: "hb2"})
+	if ref, _ := c.get("b"); ref.handle != "hb2" {
+		t.Fatalf("update b = %q", ref.handle)
 	}
 }
 

--- a/datasource/bluesky/source_test.go
+++ b/datasource/bluesky/source_test.go
@@ -106,12 +106,93 @@ func TestMapFeedItemReplyRendersResolvedSnippet(t *testing.T) {
 		if uri != parentURI {
 			return parentRef{}, false
 		}
-		return parentRef{handle: "bob.bsky.social", text: "the original hot take"}, true
+		return parentRef{name: "Bob", text: "the original hot take"}, true
 	}
 	post := mapFeedItem(item, resolve)
-	want := "yeah agreed (re: @bob.bsky.social: \"the original hot take\")"
+	want := "yeah agreed (re: Bob: \"the original hot take\")"
 	if post.Content != want {
 		t.Fatalf("content = %q, want %q", post.Content, want)
+	}
+}
+
+func TestMapFeedItemDisplayName(t *testing.T) {
+	item := FeedItem{
+		Post: PostView{
+			URI:    "at://did:plc:abc/app.bsky.feed.post/5",
+			Author: Actor{DID: "did:plc:abc", Handle: "alice.bsky.social", DisplayName: "Alice 🌸"},
+			Record: Record{Text: "hi"},
+		},
+	}
+	post := mapFeedItem(item, nil)
+	if post.Sender != "Alice 🌸" {
+		t.Fatalf("sender = %q, want display name", post.Sender)
+	}
+	// Account stays the stable DID even when the display name is shown.
+	if post.Account != "did:plc:abc" {
+		t.Fatalf("account = %q", post.Account)
+	}
+}
+
+func TestMapFeedItemRepostUsesDisplayName(t *testing.T) {
+	item := FeedItem{
+		Post: PostView{
+			URI:    "at://did:plc:abc/app.bsky.feed.post/6",
+			Author: Actor{Handle: "alice.bsky.social", DisplayName: "Alice"},
+			Record: Record{Text: "original"},
+		},
+		Reason: &FeedReason{
+			Type: "app.bsky.feed.defs#reasonRepost",
+			By:   Actor{Handle: "bob.bsky.social", DisplayName: "Bob"},
+		},
+	}
+	post := mapFeedItem(item, nil)
+	if !strings.HasPrefix(post.Content, "[RT by Bob] ") {
+		t.Fatalf("repost label = %q", post.Content)
+	}
+	if post.Sender != "Alice" {
+		t.Fatalf("sender = %q", post.Sender)
+	}
+}
+
+func TestRenderEmbedExternalTitle(t *testing.T) {
+	parts := renderEmbed(&Embed{
+		External: &EmbedExternal{URI: "https://theverge.com/x", Title: "Apple announces  thing"},
+	})
+	if len(parts) != 2 || parts[0] != "https://theverge.com/x" || parts[1] != "\"Apple announces thing\"" {
+		t.Fatalf("parts = %v", parts)
+	}
+}
+
+func TestRenderEmbedImageAlt(t *testing.T) {
+	parts := renderEmbed(&Embed{
+		Images: []EmbedImage{{Fullsize: "https://cdn/img.jpg", Alt: "a cat\nasleep"}},
+	})
+	want := []string{"https://cdn/img.jpg", "[image: a cat asleep]"}
+	if len(parts) != 2 || parts[0] != want[0] || parts[1] != want[1] {
+		t.Fatalf("parts = %v, want %v", parts, want)
+	}
+	// No alt: just the URL, no descriptor.
+	bare := renderEmbed(&Embed{Images: []EmbedImage{{Thumb: "https://cdn/t.jpg"}}})
+	if len(bare) != 1 || bare[0] != "https://cdn/t.jpg" {
+		t.Fatalf("bare = %v", bare)
+	}
+}
+
+func TestRenderEmbedVideo(t *testing.T) {
+	parts := renderEmbed(&Embed{
+		Type:      "app.bsky.embed.video#view",
+		Playlist:  "https://cdn/playlist.m3u8",
+		Thumbnail: "https://cdn/thumb.jpg",
+		Alt:       "a short clip",
+	})
+	want := []string{"https://cdn/thumb.jpg", "[video: a short clip]"}
+	if len(parts) != 2 || parts[0] != want[0] || parts[1] != want[1] {
+		t.Fatalf("parts = %v, want %v", parts, want)
+	}
+	// No alt and no thumbnail still flags the video.
+	bare := renderEmbed(&Embed{Playlist: "https://cdn/p.m3u8"})
+	if len(bare) != 1 || bare[0] != "[video]" {
+		t.Fatalf("bare = %v", bare)
 	}
 }
 
@@ -127,14 +208,14 @@ func TestMapFeedItemQuotePost(t *testing.T) {
 				Record: &EmbedRecord{
 					Type:   "app.bsky.embed.record#viewRecord",
 					URI:    "at://did:plc:xyz/app.bsky.feed.post/q",
-					Author: Actor{Handle: "carol.bsky.social"},
+					Author: Actor{Handle: "carol.bsky.social", DisplayName: "Carol"},
 					Value:  &Record{Text: "the quoted hot take"},
 				},
 			},
 		},
 	}
 	post := mapFeedItem(item, nil)
-	want := "look at this (quoting @carol.bsky.social: \"the quoted hot take\")"
+	want := "look at this (quoting Carol: \"the quoted hot take\")"
 	if post.Content != want {
 		t.Fatalf("content = %q, want %q", post.Content, want)
 	}
@@ -156,11 +237,11 @@ func TestQuotedPost(t *testing.T) {
 		Media: &Embed{External: &EmbedExternal{URI: "https://example.com/y"}},
 	}
 	q, ok := quotedPost(rwm)
-	if !ok || q.handle != "dave.bsky.social" || q.text != "nested quote" {
+	if !ok || q.name != "dave.bsky.social" || q.text != "nested quote" {
 		t.Fatalf("quoted = %+v ok=%v", q, ok)
 	}
-	if urls := collectEmbedURLs(rwm); len(urls) != 1 || urls[0] != "https://example.com/y" {
-		t.Fatalf("media urls = %v", urls)
+	if parts := renderEmbed(rwm); len(parts) != 1 || parts[0] != "https://example.com/y" {
+		t.Fatalf("media render = %v", parts)
 	}
 
 	// notFound/blocked/feed-generator stubs leave Author and Value empty.
@@ -195,7 +276,7 @@ func TestInlineParent(t *testing.T) {
 		Author: Actor{Handle: "bob.bsky.social"},
 		Record: Record{Text: "hello"},
 	}}
-	if ref, ok := inlineParent(item, uri); !ok || ref.handle != "bob.bsky.social" || ref.text != "hello" {
+	if ref, ok := inlineParent(item, uri); !ok || ref.name != "bob.bsky.social" || ref.text != "hello" {
 		t.Fatalf("inline parent = %+v ok=%v", ref, ok)
 	}
 
@@ -231,12 +312,12 @@ func TestTruncateSnippet(t *testing.T) {
 
 func TestParentCache(t *testing.T) {
 	c := newParentCache(2)
-	c.put("a", parentRef{handle: "ha"})
-	c.put("b", parentRef{handle: "hb"})
-	if ref, ok := c.get("a"); !ok || ref.handle != "ha" {
+	c.put("a", parentRef{name: "ha"})
+	c.put("b", parentRef{name: "hb"})
+	if ref, ok := c.get("a"); !ok || ref.name != "ha" {
 		t.Fatalf("get a = %+v ok=%v", ref, ok)
 	}
-	c.put("c", parentRef{handle: "hc"}) // evicts "a"
+	c.put("c", parentRef{name: "hc"}) // evicts "a"
 	if _, ok := c.get("a"); ok {
 		t.Fatal("a should have been evicted")
 	}
@@ -244,9 +325,9 @@ func TestParentCache(t *testing.T) {
 		t.Fatal("c should be present")
 	}
 	// put on existing key updates in place without eviction churn.
-	c.put("b", parentRef{handle: "hb2"})
-	if ref, _ := c.get("b"); ref.handle != "hb2" {
-		t.Fatalf("update b = %q", ref.handle)
+	c.put("b", parentRef{name: "hb2"})
+	if ref, _ := c.get("b"); ref.name != "hb2" {
+		t.Fatalf("update b = %q", ref.name)
 	}
 }
 

--- a/datasource/bluesky/source_test.go
+++ b/datasource/bluesky/source_test.go
@@ -115,6 +115,69 @@ func TestMapFeedItemReplyRendersResolvedSnippet(t *testing.T) {
 	}
 }
 
+func TestMapFeedItemQuotePost(t *testing.T) {
+	// Plain quote: app.bsky.embed.record#view carries the quoted post directly.
+	item := FeedItem{
+		Post: PostView{
+			URI:    "at://did:plc:abc/app.bsky.feed.post/4",
+			Author: Actor{Handle: "alice.bsky.social"},
+			Record: Record{Text: "look at this"},
+			Embed: &Embed{
+				Type: "app.bsky.embed.record#view",
+				Record: &EmbedRecord{
+					Type:   "app.bsky.embed.record#viewRecord",
+					URI:    "at://did:plc:xyz/app.bsky.feed.post/q",
+					Author: Actor{Handle: "carol.bsky.social"},
+					Value:  &Record{Text: "the quoted hot take"},
+				},
+			},
+		},
+	}
+	post := mapFeedItem(item, nil)
+	want := "look at this (quoting @carol.bsky.social: \"the quoted hot take\")"
+	if post.Content != want {
+		t.Fatalf("content = %q, want %q", post.Content, want)
+	}
+}
+
+func TestQuotedPost(t *testing.T) {
+	// recordWithMedia#view nests the quoted viewRecord one level deeper, and
+	// the media (images/external) is collected separately via Media.
+	rwm := &Embed{
+		Type: "app.bsky.embed.recordWithMedia#view",
+		Record: &EmbedRecord{
+			Type: "app.bsky.embed.record#view",
+			Record: &EmbedRecord{
+				Type:   "app.bsky.embed.record#viewRecord",
+				Author: Actor{Handle: "dave.bsky.social"},
+				Value:  &Record{Text: "nested quote"},
+			},
+		},
+		Media: &Embed{External: &EmbedExternal{URI: "https://example.com/y"}},
+	}
+	q, ok := quotedPost(rwm)
+	if !ok || q.handle != "dave.bsky.social" || q.text != "nested quote" {
+		t.Fatalf("quoted = %+v ok=%v", q, ok)
+	}
+	if urls := collectEmbedURLs(rwm); len(urls) != 1 || urls[0] != "https://example.com/y" {
+		t.Fatalf("media urls = %v", urls)
+	}
+
+	// notFound/blocked/feed-generator stubs leave Author and Value empty.
+	stub := &Embed{Record: &EmbedRecord{Type: "app.bsky.embed.record#viewNotFound", URI: "at://x"}}
+	if _, ok := quotedPost(stub); ok {
+		t.Fatal("expected unhydrated quote stub to be skipped")
+	}
+
+	// Non-quote embeds yield nothing.
+	if _, ok := quotedPost(&Embed{External: &EmbedExternal{URI: "https://example.com/z"}}); ok {
+		t.Fatal("external embed is not a quote")
+	}
+	if _, ok := quotedPost(nil); ok {
+		t.Fatal("nil embed is not a quote")
+	}
+}
+
 func TestInlineParent(t *testing.T) {
 	uri := "at://did:plc:xyz/app.bsky.feed.post/p"
 	base := func() FeedItem {

--- a/datasource/bluesky/types.go
+++ b/datasource/bluesky/types.go
@@ -112,7 +112,16 @@ type EmbedImageRef struct {
 	MimeType string `json:"mimeType,omitempty"`
 }
 
-// EmbedRecord is a quote post.
+// EmbedRecord models the `record` field of a quote embed. For a plain quote
+// (app.bsky.embed.record#view) it is the quoted post directly: Author and
+// Value (the app.bsky.feed.post record) are populated. For a
+// record-with-media embed the quoted post sits one level deeper under Record.
+// Non-post union members (viewNotFound, viewBlocked, viewDetached, feed
+// generators, lists, starter packs) leave Author/Value empty and are skipped.
 type EmbedRecord struct {
-	Record *PostView `json:"record,omitempty"`
+	Type   string       `json:"$type,omitempty"`
+	URI    string       `json:"uri,omitempty"`
+	Author Actor        `json:"author,omitempty"`
+	Value  *Record      `json:"value,omitempty"`
+	Record *EmbedRecord `json:"record,omitempty"`
 }

--- a/datasource/bluesky/types.go
+++ b/datasource/bluesky/types.go
@@ -23,9 +23,19 @@ type FeedResponse struct {
 
 // FeedItem is one entry in a timeline page.
 type FeedItem struct {
-	Post   PostView    `json:"post"`
-	Reason *FeedReason `json:"reason,omitempty"`
-	Reply  *ReplyRef   `json:"reply,omitempty"`
+	Post   PostView      `json:"post"`
+	Reason *FeedReason   `json:"reason,omitempty"`
+	Reply  *FeedReplyRef `json:"reply,omitempty"`
+}
+
+// FeedReplyRef is the feed-level reply context. Unlike the record-level
+// ReplyRef (which carries only uri/cid strong refs), the timeline embeds the
+// full parent/root PostViews when they are visible, letting us render a quote
+// snippet without a separate fetch. A parent that is not found, blocked, or
+// otherwise unhydrated decodes into a PostView with only URI populated.
+type FeedReplyRef struct {
+	Root   *PostView `json:"root,omitempty"`
+	Parent *PostView `json:"parent,omitempty"`
 }
 
 // PostView is the public view of a single post.

--- a/datasource/bluesky/types.go
+++ b/datasource/bluesky/types.go
@@ -82,14 +82,18 @@ type FeedReason struct {
 	By   Actor  `json:"by"`
 }
 
-// Embed is the union of embedded content kinds we care about for previews.
-// All fields optional; presence depends on $type.
+// Embed is the union of embedded content kinds we care about. All fields
+// optional; presence depends on $type. Video views (app.bsky.embed.video#view)
+// carry playlist/thumbnail/alt at the top level rather than under a nested key.
 type Embed struct {
-	Type     string         `json:"$type,omitempty"`
-	External *EmbedExternal `json:"external,omitempty"`
-	Images   []EmbedImage   `json:"images,omitempty"`
-	Media    *Embed         `json:"media,omitempty"` // embeds with record+media wrap a nested embed
-	Record   *EmbedRecord   `json:"record,omitempty"`
+	Type      string         `json:"$type,omitempty"`
+	External  *EmbedExternal `json:"external,omitempty"`
+	Images    []EmbedImage   `json:"images,omitempty"`
+	Playlist  string         `json:"playlist,omitempty"`  // video#view: m3u8
+	Thumbnail string         `json:"thumbnail,omitempty"` // video#view: poster image
+	Alt       string         `json:"alt,omitempty"`       // video#view alt text
+	Media     *Embed         `json:"media,omitempty"`     // recordWithMedia wraps a nested embed
+	Record    *EmbedRecord   `json:"record,omitempty"`
 }
 
 // EmbedExternal is an OG card.


### PR DESCRIPTION
Replies previously appended the bare parent post URI as
"(re: at://...)", which is unreadable in the buffer. Resolve the
parent post and render a glanceable snippet:
"(re: @handle: \"parent text…\")".

Resolution is best-effort, per poll, in priority order:
- Use the parent PostView the timeline already embeds under
  feedViewPost.reply.parent (no extra request).
- Batch-hydrate the rest via app.bsky.feed.getPosts (25 URIs/call).
- Fall back to the raw at:// URI so context is never dropped.

Resolved parents are cached in a small per-channel FIFO map so a
parent is hydrated once and reused across sibling replies and
subsequent polls. Snippet text is whitespace-collapsed and
truncated to ~100 runes.

https://claude.ai/code/session_01JtFQCYYa4ZuscxhJg6Ni1L