### PR TITLE
refactor: collapse triplicate channel-member structs (fixes #89)

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -56,27 +56,18 @@ type messageDTO struct {
 	Previews []preview.ResolvedPreview `json:"previews,omitzero"`
 }
 
-type channelMemberDTO struct {
-	Nick     string `json:"nick"`
-	Prefix   string `json:"prefix,omitzero"`
-	Realname string `json:"realname,omitzero"`
-	Away     bool   `json:"away"`
-	Self     bool   `json:"self"`
-	Color    int    `json:"color"`
-}
-
 type stateDTO struct {
-	Networks        []networkDTO                  `json:"networks"`
-	Buffers         []bufferDTO                   `json:"buffers"`
-	InitialMessages map[string][]messageDTO       `json:"initial_messages"`
-	Members         map[string][]channelMemberDTO `json:"members,omitzero"`
+	Networks        []networkDTO              `json:"networks"`
+	Buffers         []bufferDTO               `json:"buffers"`
+	InitialMessages map[string][]messageDTO   `json:"initial_messages"`
+	Members         map[string][]irc.ChannelUser `json:"members,omitzero"`
 }
 
 // stateManager is the IRC runtime state surface needed by /api/state.
 type stateManager interface {
 	StateSnapshot() map[uuid.UUID]string
 	IsJoined(networkID uuid.UUID, channel string) bool
-	ChannelMembers(networkID uuid.UUID, channel string) []ircdb.ChannelMember
+	ChannelMembers(networkID uuid.UUID, channel string) []irc.ChannelUser
 	Nick(networkID uuid.UUID) string
 }
 
@@ -98,7 +89,7 @@ func (s *Server) state(w http.ResponseWriter, r *http.Request) {
 		Networks:        make([]networkDTO, 0, len(nets)),
 		Buffers:         make([]bufferDTO, 0, len(bufs)),
 		InitialMessages: map[string][]messageDTO{},
-		Members:         map[string][]channelMemberDTO{},
+		Members:         map[string][]irc.ChannelUser{},
 	}
 	states := map[uuid.UUID]string{}
 	if s.Manager != nil {
@@ -132,7 +123,7 @@ func (s *Server) appendBufferToState(ctx context.Context, out *stateDTO, b ircdb
 	})
 	if b.Kind == ircdb.BufferChannel && s.Manager != nil {
 		if members := s.Manager.ChannelMembers(b.NetworkID, b.Name); members != nil {
-			out.Members[b.ID.String()] = toChannelMemberDTOs(members)
+			out.Members[b.ID.String()] = members
 		}
 	}
 	msgs, err := s.Stores.RecentMessages(ctx, b.ID, 100)
@@ -368,13 +359,6 @@ func (s *Server) computeUnreadCounts(ctx context.Context, networkID, bufferID, l
 	return unread, mentions
 }
 
-func toChannelMemberDTOs(in []ircdb.ChannelMember) []channelMemberDTO {
-	out := make([]channelMemberDTO, 0, len(in))
-	for _, m := range in {
-		out = append(out, channelMemberDTO{Nick: m.Nick, Prefix: m.Prefix, Realname: m.Realname, Away: m.Away, Self: m.Self, Color: m.Color})
-	}
-	return out
-}
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	data, err := json.Marshal(v)

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -130,23 +130,19 @@ func TestLoadHistoryRecentWhenBeforeIsNil(t *testing.T) {
 	}
 }
 
-func TestToChannelMemberDTOsEmptyAndPartial(t *testing.T) {
-	if got := toChannelMemberDTOs(nil); len(got) != 0 {
-		t.Fatalf("nil input got %d entries", len(got))
-	}
-	in := []ircdb.ChannelMember{
+func TestChannelMembersWireShape(t *testing.T) {
+	members := []irc.ChannelUser{
 		{Nick: "alice", Prefix: "@", Self: true},
 		{Nick: "bob"},
 	}
-	got := toChannelMemberDTOs(in)
-	if len(got) != 2 {
-		t.Fatalf("len = %d want 2", len(got))
+	if len(members) != 2 {
+		t.Fatalf("len = %d want 2", len(members))
 	}
-	if got[0].Nick != "alice" || got[0].Prefix != "@" || !got[0].Self {
-		t.Fatalf("alice dto = %+v", got[0])
+	if members[0].Nick != "alice" || members[0].Prefix != "@" || !members[0].Self {
+		t.Fatalf("alice = %+v", members[0])
 	}
-	if got[1].Nick != "bob" || got[1].Prefix != "" || got[1].Self || got[1].Away {
-		t.Fatalf("bob dto = %+v", got[1])
+	if members[1].Nick != "bob" || members[1].Prefix != "" || members[1].Self || members[1].Away {
+		t.Fatalf("bob = %+v", members[1])
 	}
 }
 

--- a/api/ws_protocol_test.go
+++ b/api/ws_protocol_test.go
@@ -235,7 +235,7 @@ func (m *mockState) IsJoined(networkID uuid.UUID, channel string) bool {
 	return false
 }
 
-func (m *mockState) ChannelMembers(networkID uuid.UUID, channel string) []ircdb.ChannelMember {
+func (m *mockState) ChannelMembers(networkID uuid.UUID, channel string) []irc.ChannelUser {
 	_ = m.record("ChannelMembers", networkID, channel)
 	return nil
 }

--- a/db/multistore.go
+++ b/db/multistore.go
@@ -23,17 +23,6 @@ type resolvedGlobalBuffer struct {
 	logStore  *LogStore
 }
 
-// ChannelMember is runtime member state for a channel user. Color is the
-// server-computed nickcolor palette index.
-type ChannelMember struct {
-	Nick     string
-	Prefix   string
-	Realname string
-	Away     bool
-	Self     bool
-	Color    int
-}
-
 // MultiStore owns the control DB plus zero or more per-network log DB handles.
 // It also owns the shared URL-preview cache, which is deliberately a single
 // database shared across every network: a link reposted between networks or

--- a/irc/channel_members.go
+++ b/irc/channel_members.go
@@ -9,16 +9,7 @@ import (
 	"github.com/lrstanley/girc"
 )
 
-type channelMember struct {
-	Nick     string
-	Prefix   string
-	Realname string
-	Away     bool
-	Self     bool
-	Color    int
-}
-
-func buildChannelMembers(c *girc.Client, channel string) []channelMember {
+func buildChannelMembers(c *girc.Client, channel string) []ChannelUser {
 	if c == nil || channel == "" {
 		return nil
 	}
@@ -26,7 +17,7 @@ func buildChannelMembers(c *girc.Client, channel string) []channelMember {
 	if ch == nil {
 		return nil
 	}
-	members := make([]channelMember, 0, len(ch.UserList))
+	members := make([]ChannelUser, 0, len(ch.UserList))
 	selfNick := c.GetNick()
 	for _, nick := range ch.UserList {
 		user := c.LookupUser(nick)
@@ -40,7 +31,7 @@ func buildChannelMembers(c *girc.Client, channel string) []channelMember {
 			// clients render it as plain text, so strip codes server-side.
 			realname = strings.TrimSpace(mirc.Strip(user.Extras.Name))
 		}
-		members = append(members, channelMember{
+		members = append(members, ChannelUser{
 			Nick:     displayNick,
 			Prefix:   channelMemberPrefix(user, channel),
 			Realname: realname,

--- a/irc/fixture_runtime.go
+++ b/irc/fixture_runtime.go
@@ -25,7 +25,7 @@ func (m *Manager) LoadFixtureRuntimeState(ctx context.Context) error {
 	nicks := map[uuid.UUID]string{}
 	states := map[uuid.UUID]string{}
 	joined := map[uuid.UUID]map[string]bool{}
-	members := map[uuid.UUID]map[string][]ircdb.ChannelMember{}
+	members := map[uuid.UUID]map[string][]ChannelUser{}
 	for _, n := range nets {
 		nicks[n.ID] = n.Nick
 		states[n.ID] = StateConnected.String()
@@ -42,7 +42,7 @@ func (m *Manager) LoadFixtureRuntimeState(ctx context.Context) error {
 		}
 		joined[b.NetworkID][b.Name] = true
 		if members[b.NetworkID] == nil {
-			members[b.NetworkID] = map[string][]ircdb.ChannelMember{}
+			members[b.NetworkID] = map[string][]ChannelUser{}
 		}
 		members[b.NetworkID][b.Name] = m.fixtureMembersForChannel(ctx, b.ID, nicks[b.NetworkID])
 	}
@@ -57,7 +57,7 @@ func (m *Manager) LoadFixtureRuntimeState(ctx context.Context) error {
 	return nil
 }
 
-func (m *Manager) fixtureMembersForChannel(ctx context.Context, bufferID uuid.UUID, selfNick string) []ircdb.ChannelMember {
+func (m *Manager) fixtureMembersForChannel(ctx context.Context, bufferID uuid.UUID, selfNick string) []ChannelUser {
 	seen := map[string]bool{}
 	if selfNick != "" {
 		seen[strings.ToLower(selfNick)] = true
@@ -72,9 +72,9 @@ func (m *Manager) fixtureMembersForChannel(ctx context.Context, bufferID uuid.UU
 		}
 	}
 
-	out := make([]ircdb.ChannelMember, 0, len(seen))
+	out := make([]ChannelUser, 0, len(seen))
 	for nick := range seen {
-		member := ircdb.ChannelMember{Nick: nick, Self: strings.EqualFold(nick, selfNick)}
+		member := ChannelUser{Nick: nick, Self: strings.EqualFold(nick, selfNick)}
 		if member.Self {
 			member.Nick = selfNick
 			member.Prefix = "+"

--- a/irc/handler_presence.go
+++ b/irc/handler_presence.go
@@ -137,14 +137,10 @@ func (h *handler) publishMemberList(c *girc.Client, channel string) {
 		slog.Error("ensure names buffer", "err", err, "network", h.networkName, "buffer", channel)
 		return
 	}
-	out := make([]ChannelUser, 0, len(members))
-	for _, member := range members {
-		out = append(out, ChannelUser(member))
-	}
-	if h.memberListUnchanged(channel, out) {
+	if h.memberListUnchanged(channel, members) {
 		return
 	}
-	h.hub.Publish(&MemberListEvent{Type: "member_list", NetworkID: h.networkID, BufferID: globalBufID, Channel: channel, Members: out})
+	h.hub.Publish(&MemberListEvent{Type: "member_list", NetworkID: h.networkID, BufferID: globalBufID, Channel: channel, Members: members})
 }
 
 func (h *handler) memberListUnchanged(channel string, members []ChannelUser) bool {

--- a/irc/manager.go
+++ b/irc/manager.go
@@ -85,7 +85,7 @@ type Manager struct {
 	runtime        map[uuid.UUID]networkRuntime
 	membersLoaded  map[uuid.UUID]map[string]bool
 	joined         map[uuid.UUID]map[string]bool
-	fixtureMembers map[uuid.UUID]map[string][]ircdb.ChannelMember
+	fixtureMembers map[uuid.UUID]map[string][]ChannelUser
 	connector      connectorFunc
 }
 
@@ -99,7 +99,7 @@ func NewManager(stores *ircdb.MultiStore, h *hub.Hub) *Manager {
 		runtime:        map[uuid.UUID]networkRuntime{},
 		membersLoaded:  map[uuid.UUID]map[string]bool{},
 		joined:         map[uuid.UUID]map[string]bool{},
-		fixtureMembers: map[uuid.UUID]map[string][]ircdb.ChannelMember{},
+		fixtureMembers: map[uuid.UUID]map[string][]ChannelUser{},
 		connector:      defaultConnector,
 	}
 }
@@ -492,7 +492,7 @@ func (m *Manager) StateSnapshot() map[uuid.UUID]string {
 }
 
 // ChannelMembers returns the currently tracked members for a joined channel.
-func (m *Manager) ChannelMembers(networkID uuid.UUID, channel string) []ircdb.ChannelMember {
+func (m *Manager) ChannelMembers(networkID uuid.UUID, channel string) []ChannelUser {
 	m.mu.Lock()
 	c := m.conn[networkID]
 	loaded := m.membersLoaded[networkID][channel]
@@ -507,22 +507,11 @@ func (m *Manager) ChannelMembers(networkID uuid.UUID, channel string) []ircdb.Ch
 	members := buildChannelMembers(c, channel)
 	if members == nil {
 		if loaded {
-			return []ircdb.ChannelMember{}
+			return []ChannelUser{}
 		}
 		return nil
 	}
-	out := make([]ircdb.ChannelMember, 0, len(members))
-	for _, member := range members {
-		out = append(out, ircdb.ChannelMember{
-			Nick:     member.Nick,
-			Prefix:   member.Prefix,
-			Realname: member.Realname,
-			Away:     member.Away,
-			Self:     member.Self,
-			Color:    member.Color,
-		})
-	}
-	return out
+	return members
 }
 
 // IsJoined returns whether a JOIN has been seen for the given channel on


### PR DESCRIPTION
## Summary

- Drop `db.ChannelMember` — runtime-only type that lived in the wrong package
- Drop `api.channelMemberDTO` — identical to `irc.ChannelUser` modulo JSON tags
- Drop private `channelMember` in `irc/channel_members.go` — same struct again
- `irc.ChannelUser` is now the single canonical type; `buildChannelMembers` returns it directly
- `Manager.ChannelMembers` return type changed to `[]irc.ChannelUser`
- `toChannelMemberDTOs` converter removed (was identity copy)
- Wire shape (`member_list` event and `/api/state` response) is unchanged

Closes #89

## Test plan

- [x] `task test` green (all packages)
- [x] Build passes (`go build ./...`)
- [x] Wire shape verified: `irc.ChannelUser` JSON tags match the dropped `channelMemberDTO` tags