### PR TITLE
refactor(irc): export PublishBufferCreated/PublishNetworkState helpers

### DIFF
--- a/datasource/bluesky/source.go
+++ b/datasource/bluesky/source.go
@@ -110,13 +110,7 @@ func (s *Source) Start(parent context.Context, deps datasource.Deps) error {
 	}
 	s.statusBufferID = statusID
 
-	if deps.Hub != nil {
-		deps.Hub.Publish(&irc.NetworkStateEvent{
-			Type:      "network_state",
-			NetworkID: nrow.ID,
-			State:     irc.StateConnected.String(),
-		})
-	}
+	irc.PublishNetworkState(deps.Hub, nrow.ID, irc.StateConnected)
 	slog.Info("data source connected", "source", "bluesky", "network", s.cfg.Network, "handle", handle)
 
 	for _, rc := range resolved {
@@ -160,15 +154,8 @@ func (s *Source) resolveChannels(parent context.Context, deps datasource.Deps, n
 		if berr != nil {
 			return nil, fmt.Errorf("ensure buffer %q: %w", ch.Name, berr)
 		}
-		if created && deps.Hub != nil {
-			deps.Hub.Publish(&irc.BufferCreatedEvent{
-				Type:      "buffer_created",
-				ID:        buf.ID,
-				NetworkID: nrow.ID,
-				Name:      buf.Name,
-				Kind:      buf.Kind,
-				CreatedAt: buf.CreatedAt,
-			})
+		if created {
+			irc.PublishBufferCreated(deps.Hub, buf)
 		}
 		resolved = append(resolved, runtimeChannel{cfg: ch, bufferID: bufID})
 	}

--- a/irc/handler_helpers.go
+++ b/irc/handler_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	ircdb "github.com/lepinkainen/lurker/db"
+	"github.com/lepinkainen/lurker/hub"
 	"github.com/lrstanley/girc"
 )
 
@@ -49,15 +50,31 @@ func (h *handler) ensureBuffer(ctx context.Context, name, kind string) (bufID uu
 	if err != nil {
 		return uuid.Nil, err
 	}
-	h.publishBufferCreated(created, bufID, buf)
+	h.publishBufferCreated(created, buf)
 	return bufID, nil
 }
 
-func (h *handler) publishBufferCreated(created bool, bufID uuid.UUID, buf ircdb.Buffer) {
-	if !created || h.hub == nil {
+// PublishBufferCreated publishes a buffer_created event to h. No-op if h is nil.
+func PublishBufferCreated(h *hub.Hub, buf ircdb.Buffer) {
+	if h == nil {
 		return
 	}
-	h.hub.Publish(&BufferCreatedEvent{Type: "buffer_created", ID: bufID, NetworkID: buf.NetworkID, Name: buf.Name, Kind: buf.Kind, CreatedAt: buf.CreatedAt})
+	h.Publish(&BufferCreatedEvent{Type: "buffer_created", ID: buf.ID, NetworkID: buf.NetworkID, Name: buf.Name, Kind: buf.Kind, CreatedAt: buf.CreatedAt})
+}
+
+// PublishNetworkState publishes a network_state event to h. No-op if h is nil.
+func PublishNetworkState(h *hub.Hub, networkID uuid.UUID, state NetworkState) {
+	if h == nil {
+		return
+	}
+	h.Publish(&NetworkStateEvent{Type: "network_state", NetworkID: networkID, State: state.String()})
+}
+
+func (h *handler) publishBufferCreated(created bool, buf ircdb.Buffer) {
+	if !created {
+		return
+	}
+	PublishBufferCreated(h.hub, buf)
 }
 
 func (h *handler) publishBufferUpdate(ev BufferUpdateEvent) {
@@ -68,8 +85,5 @@ func (h *handler) publishBufferUpdate(ev BufferUpdateEvent) {
 }
 
 func (h *handler) publishNetworkState(state NetworkState) {
-	if h.hub == nil {
-		return
-	}
-	h.hub.Publish(&NetworkStateEvent{Type: "network_state", NetworkID: h.networkID, State: state.String()})
+	PublishNetworkState(h.hub, h.networkID, state)
 }

--- a/irc/manager.go
+++ b/irc/manager.go
@@ -173,9 +173,7 @@ func (m *Manager) StopNetwork(networkID uuid.UUID) error {
 	if c != nil {
 		c.Close()
 	}
-	if m.hub != nil {
-		m.hub.Publish(&NetworkStateEvent{Type: "network_state", NetworkID: networkID, State: StateDisconnected.String()})
-	}
+	PublishNetworkState(m.hub, networkID, StateDisconnected)
 	return nil
 }
 
@@ -645,9 +643,7 @@ func (m *Manager) setConnectingState(networkID uuid.UUID, client *girc.Client) {
 	m.conn[networkID] = client
 	m.state[networkID] = StateConnecting.String()
 	m.mu.Unlock()
-	if m.hub != nil {
-		m.hub.Publish(&NetworkStateEvent{Type: "network_state", NetworkID: networkID, State: StateConnecting.String()})
-	}
+	PublishNetworkState(m.hub, networkID, StateConnecting)
 }
 
 func (m *Manager) connectWithTLS12Fallback(ctx context.Context, log *slog.Logger, networkID uuid.UUID, nc NetworkConfig, server ServerConfig, firstErr error) error {
@@ -670,9 +666,7 @@ func (m *Manager) markDisconnected(networkID uuid.UUID) {
 		m.state[networkID] = StateDisconnected.String()
 	}
 	m.mu.Unlock()
-	if m.hub != nil {
-		m.hub.Publish(&NetworkStateEvent{Type: "network_state", NetworkID: networkID, State: StateDisconnected.String()})
-	}
+	PublishNetworkState(m.hub, networkID, StateDisconnected)
 }
 
 func defaultConnector(_ context.Context, client *girc.Client, _ ServerConfig) error {


### PR DESCRIPTION
## Summary

- Promote `publishBufferCreated` and `publishNetworkState` from unexported `*handler` methods to package-level `PublishBufferCreated`/`PublishNetworkState` functions
- `irc/manager.go` inline `NetworkStateEvent` constructions replaced with `PublishNetworkState` calls
- `datasource/bluesky/source.go` inline event constructions replaced with the new helpers

## Test plan

- [x] `task test` passes
- [x] `task lint` clean (0 issues)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)