### PR TITLE
feat(httpjson): extract shared HTTP+JSON helper; migrate bluesky, updates, tui

### DIFF
--- a/cmd/tui/client.go
+++ b/cmd/tui/client.go
@@ -15,16 +15,13 @@ import (
 
 type apiClient struct {
 	baseURL string
-	http    *http.Client
 	hjc     *httpjson.Client
 }
 
 func newAPIClient(baseURL string) *apiClient {
-	hc := &http.Client{}
 	return &apiClient{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		http:    hc,
-		hjc:     &httpjson.Client{HTTP: hc},
+		hjc:     &httpjson.Client{HTTP: &http.Client{}},
 	}
 }
 

--- a/cmd/tui/client.go
+++ b/cmd/tui/client.go
@@ -2,60 +2,44 @@ package main
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/google/uuid"
+	"github.com/lepinkainen/lurker/internal/httpjson"
 )
 
 type apiClient struct {
 	baseURL string
 	http    *http.Client
+	hjc     *httpjson.Client
 }
 
 func newAPIClient(baseURL string) *apiClient {
+	hc := &http.Client{}
 	return &apiClient{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		http:    &http.Client{},
+		http:    hc,
+		hjc:     &httpjson.Client{HTTP: hc},
 	}
 }
 
 func (c *apiClient) fetchState(ctx context.Context) (*stateResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/state", http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("build state request: %w", err)
-	}
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetch state: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read state: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		preview := string(body)
-		if len(preview) > 200 {
-			preview = preview[:200]
-		}
-		return nil, fmt.Errorf("parse state: server returned %d: %s", resp.StatusCode, preview)
-	}
-
 	var state stateResponse
-	if err := json.Unmarshal(body, &state); err != nil {
-		preview := string(body)
-		if len(preview) > 200 {
-			preview = preview[:200]
+	if err := c.hjc.DoJSON(ctx, httpjson.Request{URL: c.baseURL + "/api/state"}, &state); err != nil {
+		var herr *httpjson.Error
+		if errors.As(err, &herr) {
+			preview := string(herr.Body)
+			if len(preview) > 200 {
+				preview = preview[:200]
+			}
+			return nil, fmt.Errorf("fetch state: server returned %d: %s", herr.Status, preview)
 		}
-		return nil, fmt.Errorf("parse state: %w (body: %s)", err, preview)
+		return nil, fmt.Errorf("fetch state: %w", err)
 	}
 	return &state, nil
 }

--- a/datasource/bluesky/client.go
+++ b/datasource/bluesky/client.go
@@ -4,18 +4,18 @@
 package bluesky
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/lepinkainen/lurker/internal/httpjson"
 )
 
 // DefaultPDS is bsky.social, the canonical entry PDS. Per-account PDS hosts
@@ -31,7 +31,7 @@ type Client struct {
 	identifier string
 	password   string
 
-	http *http.Client
+	hjc *httpjson.Client
 
 	mu         sync.Mutex
 	accessJwt  string
@@ -51,7 +51,7 @@ func NewClient(pds, identifier, password string) *Client {
 		pds:        pds,
 		identifier: identifier,
 		password:   password,
-		http:       &http.Client{Timeout: HTTPTimeout},
+		hjc:        &httpjson.Client{HTTP: &http.Client{Timeout: HTTPTimeout}},
 	}
 }
 
@@ -199,7 +199,7 @@ func (c *Client) callAuthed(ctx context.Context, method, nsid string, q url.Valu
 // access-JWT expiry, and 400 + error:"ExpiredToken"/"InvalidToken" on
 // refresh-JWT expiry; 401 also covers older/edge cases.
 func isExpiredAuthErr(err error) bool {
-	var herr *httpError
+	var herr *httpjson.Error
 	if !errors.As(err, &herr) {
 		return false
 	}
@@ -209,7 +209,7 @@ func isExpiredAuthErr(err error) bool {
 	if herr.Status != http.StatusBadRequest {
 		return false
 	}
-	switch herr.Code {
+	switch parseXRPCErrorCode(herr.Body) {
 	case "ExpiredToken", "InvalidToken", "AuthenticationRequired":
 		return true
 	}
@@ -228,17 +228,6 @@ func parseXRPCErrorCode(raw []byte) string {
 	return env.Error
 }
 
-// httpError carries non-2xx XRPC responses.
-type httpError struct {
-	Status int
-	Code   string
-	Body   string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("xrpc http %d: %s", e.Status, e.Body)
-}
-
 // doJSON is the unifying request helper. Pass bearer="" for unauthenticated
 // calls; body=nil for GET-style calls (query-string only).
 func (c *Client) doJSON(ctx context.Context, method, nsid string, q url.Values, bearer string, body, out any) error {
@@ -246,45 +235,14 @@ func (c *Client) doJSON(ctx context.Context, method, nsid string, q url.Values, 
 	if len(q) > 0 {
 		u += "?" + q.Encode()
 	}
-
-	var reqBody io.Reader
-	if body != nil {
-		buf, err := json.Marshal(body)
-		if err != nil {
-			return fmt.Errorf("marshal body: %w", err)
-		}
-		reqBody = bytes.NewReader(buf)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, u, reqBody)
-	if err != nil {
-		return err
-	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	req.Header.Set("Accept", "application/json")
+	var auth string
 	if bearer != "" {
-		req.Header.Set("Authorization", "Bearer "+bearer)
+		auth = "Bearer " + bearer
 	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &httpError{Status: resp.StatusCode, Code: parseXRPCErrorCode(raw), Body: string(raw)}
-	}
-	if out == nil {
-		return nil
-	}
-	if err := json.Unmarshal(raw, out); err != nil {
-		return fmt.Errorf("decode response: %w", err)
-	}
-	return nil
+	return c.hjc.DoJSON(ctx, httpjson.Request{
+		Method:        method,
+		URL:           u,
+		Body:          body,
+		Authorization: auth,
+	}, out)
 }

--- a/datasource/bluesky/client_test.go
+++ b/datasource/bluesky/client_test.go
@@ -3,11 +3,14 @@ package bluesky
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/lepinkainen/lurker/internal/httpjson"
 )
 
 func TestParseXRPCErrorCode(t *testing.T) {
@@ -27,20 +30,24 @@ func TestParseXRPCErrorCode(t *testing.T) {
 	}
 }
 
+func xrpcBody(code string) []byte {
+	return []byte(fmt.Sprintf(`{"error":%q}`, code))
+}
+
 func TestIsExpiredAuthErr(t *testing.T) {
 	cases := []struct {
 		name string
 		err  error
 		want bool
 	}{
-		{"401 unauthorized", &httpError{Status: 401}, true},
-		{"400 ExpiredToken", &httpError{Status: 400, Code: "ExpiredToken"}, true},
-		{"400 InvalidToken", &httpError{Status: 400, Code: "InvalidToken"}, true},
-		{"400 AuthenticationRequired", &httpError{Status: 400, Code: "AuthenticationRequired"}, true},
-		{"400 other code", &httpError{Status: 400, Code: "InvalidRequest"}, false},
-		{"500", &httpError{Status: 500, Code: "ExpiredToken"}, false},
+		{"401 unauthorized", &httpjson.Error{Status: 401}, true},
+		{"400 ExpiredToken", &httpjson.Error{Status: 400, Body: xrpcBody("ExpiredToken")}, true},
+		{"400 InvalidToken", &httpjson.Error{Status: 400, Body: xrpcBody("InvalidToken")}, true},
+		{"400 AuthenticationRequired", &httpjson.Error{Status: 400, Body: xrpcBody("AuthenticationRequired")}, true},
+		{"400 other code", &httpjson.Error{Status: 400, Body: xrpcBody("InvalidRequest")}, false},
+		{"500", &httpjson.Error{Status: 500, Body: xrpcBody("ExpiredToken")}, false},
 		{"plain error", errors.New("dial tcp: refused"), false},
-		{"wrapped httpError", errOpWrap(&httpError{Status: 401}), true},
+		{"wrapped httpError", errOpWrap(&httpjson.Error{Status: 401}), true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/httpjson/httpjson.go
+++ b/internal/httpjson/httpjson.go
@@ -1,0 +1,128 @@
+// Package httpjson provides a shared HTTP+JSON request helper.
+package httpjson
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+)
+
+const (
+	defaultMaxBytes = 4 << 20 // 4 MiB
+	maxErrorBytes   = 2 << 10 // 2 KiB — safe to log
+)
+
+// Client is a reusable HTTP+JSON client. Zero value is usable with defaults.
+type Client struct {
+	HTTP     *http.Client // nil → http.DefaultClient
+	MaxBytes int64        // response body cap; 0 → 4 MiB
+}
+
+// Request describes a single HTTP call.
+type Request struct {
+	Method        string // default: GET
+	URL           string
+	Body          any         // marshaled as JSON; sets Content-Type when non-nil
+	Header        http.Header // merged over defaults; caller wins (including Accept)
+	Authorization string      // full value: "Bearer x" or "Basic y"
+}
+
+// Response carries a 2xx reply.
+type Response struct {
+	Status int
+	Header http.Header
+	Body   []byte
+}
+
+// Error carries a non-2xx reply. Body is truncated to 2 KiB for safe logging.
+type Error struct {
+	Status int
+	Header http.Header
+	Body   []byte
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("http %d: %s", e.Status, e.Body)
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return http.DefaultClient
+}
+
+func (c *Client) limit() int64 {
+	if c.MaxBytes > 0 {
+		return c.MaxBytes
+	}
+	return defaultMaxBytes
+}
+
+// Do executes the request. Returns *Error for non-2xx status codes.
+func (c *Client) Do(ctx context.Context, r Request) (*Response, error) {
+	method := r.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	var reqBody io.Reader
+	if r.Body != nil {
+		buf, err := json.Marshal(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal body: %w", err)
+		}
+		reqBody = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, r.URL, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// Default Accept; caller-supplied header overrides.
+	req.Header.Set("Accept", "application/json")
+	maps.Copy(req.Header, r.Header)
+	if r.Body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if r.Authorization != "" {
+		req.Header.Set("Authorization", r.Authorization)
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBytes))
+		return nil, &Error{Status: resp.StatusCode, Header: resp.Header, Body: errBody}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, c.limit()))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	return &Response{Status: resp.StatusCode, Header: resp.Header, Body: body}, nil
+}
+
+// DoJSON calls Do and unmarshals the 2xx body into out. Pass nil out to skip decode.
+func (c *Client) DoJSON(ctx context.Context, r Request, out any) error {
+	resp, err := c.Do(ctx, r)
+	if err != nil {
+		return err
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(resp.Body, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/internal/httpjson/httpjson.go
+++ b/internal/httpjson/httpjson.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"net/http"
+	"slices"
 )
 
 const (
@@ -27,7 +27,7 @@ type Request struct {
 	Method        string // default: GET
 	URL           string
 	Body          any         // marshaled as JSON; sets Content-Type when non-nil
-	Header        http.Header // merged over defaults; caller wins (including Accept)
+	Header        http.Header // merged over defaults; overrides Accept, but Body's Content-Type and the Authorization field win
 	Authorization string      // full value: "Bearer x" or "Basic y"
 }
 
@@ -86,7 +86,9 @@ func (c *Client) Do(ctx context.Context, r Request) (*Response, error) {
 
 	// Default Accept; caller-supplied header overrides.
 	req.Header.Set("Accept", "application/json")
-	maps.Copy(req.Header, r.Header)
+	for k, vs := range r.Header {
+		req.Header[http.CanonicalHeaderKey(k)] = slices.Clone(vs)
+	}
 	if r.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -122,7 +124,11 @@ func (c *Client) DoJSON(ctx context.Context, r Request, out any) error {
 		return nil
 	}
 	if err := json.Unmarshal(resp.Body, out); err != nil {
-		return fmt.Errorf("decode response: %w", err)
+		preview := resp.Body
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		return fmt.Errorf("decode response: %w (body: %s)", err, preview)
 	}
 	return nil
 }

--- a/internal/httpjson/httpjson_test.go
+++ b/internal/httpjson/httpjson_test.go
@@ -215,6 +215,44 @@ func TestDo_DefaultMethod_IsGET(t *testing.T) {
 	}
 }
 
+func TestDo_NonCanonicalHeaderKeyOverridesDefault(t *testing.T) {
+	const want = "application/activity+json"
+	var gotAccept []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Values("Accept")
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, _ = c.Do(context.Background(), httpjson.Request{
+		URL:    srv.URL,
+		Header: http.Header{"accept": []string{want}},
+	})
+	if len(gotAccept) != 1 || gotAccept[0] != want {
+		t.Errorf("Accept = %v, want [%s]", gotAccept, want)
+	}
+}
+
+func TestDoJSON_DecodeErrorIncludesBodyPreview(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>` + strings.Repeat("x", 400)))
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	var out struct{}
+	err := c.DoJSON(context.Background(), httpjson.Request{URL: srv.URL}, &out)
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if !strings.Contains(err.Error(), "<html>not json</html>") {
+		t.Errorf("error missing body preview: %v", err)
+	}
+	if len(err.Error()) > 400 {
+		t.Errorf("error not truncated, len = %d", len(err.Error()))
+	}
+}
+
 func isErrorAs(err error, target **httpjson.Error) bool {
 	return errors.As(err, target)
 }

--- a/internal/httpjson/httpjson_test.go
+++ b/internal/httpjson/httpjson_test.go
@@ -1,0 +1,220 @@
+package httpjson_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lepinkainen/lurker/internal/httpjson"
+)
+
+func TestDo_2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Custom", "yes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	resp, err := c.Do(context.Background(), httpjson.Request{URL: srv.URL})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if string(resp.Body) != `{"ok":true}` {
+		t.Errorf("body = %q", resp.Body)
+	}
+	if resp.Header.Get("X-Custom") != "yes" {
+		t.Error("response header not propagated")
+	}
+}
+
+func TestDo_NonOK_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Err", "detail")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, err := c.Do(context.Background(), httpjson.Request{URL: srv.URL})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var herr *httpjson.Error
+	if !isErrorAs(err, &herr) {
+		t.Fatalf("err type = %T, want *httpjson.Error", err)
+	}
+	if herr.Status != http.StatusUnauthorized {
+		t.Errorf("Status = %d, want 401", herr.Status)
+	}
+	if herr.Header.Get("X-Err") != "detail" {
+		t.Error("error header not propagated")
+	}
+	if !strings.Contains(string(herr.Body), "Unauthorized") {
+		t.Errorf("body = %q", herr.Body)
+	}
+}
+
+func TestDo_ErrorBodyTruncatedAt2KiB(t *testing.T) {
+	bigBody := strings.Repeat("x", 4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(bigBody))
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, err := c.Do(context.Background(), httpjson.Request{URL: srv.URL})
+	var herr *httpjson.Error
+	if !isErrorAs(err, &herr) {
+		t.Fatalf("err type = %T", err)
+	}
+	if len(herr.Body) > 2048 {
+		t.Errorf("error body len = %d, want ≤ 2048", len(herr.Body))
+	}
+}
+
+func TestDo_BodyCapApplied(t *testing.T) {
+	payload := strings.Repeat("a", 100)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client(), MaxBytes: 50}
+	resp, err := c.Do(context.Background(), httpjson.Request{URL: srv.URL})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Body) != 50 {
+		t.Errorf("body len = %d, want 50", len(resp.Body))
+	}
+}
+
+func TestDo_DefaultAcceptHeader(t *testing.T) {
+	var gotAccept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Get("Accept")
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, _ = c.Do(context.Background(), httpjson.Request{URL: srv.URL})
+	if gotAccept != "application/json" {
+		t.Errorf("Accept = %q, want application/json", gotAccept)
+	}
+}
+
+func TestDo_CallerAcceptOverridesDefault(t *testing.T) {
+	const want = "application/activity+json"
+	var gotAccept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Get("Accept")
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, _ = c.Do(context.Background(), httpjson.Request{
+		URL:    srv.URL,
+		Header: http.Header{"Accept": []string{want}},
+	})
+	if gotAccept != want {
+		t.Errorf("Accept = %q, want %q", gotAccept, want)
+	}
+}
+
+func TestDo_AuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, _ = c.Do(context.Background(), httpjson.Request{
+		URL:           srv.URL,
+		Authorization: "Bearer testtoken",
+	})
+	if gotAuth != "Bearer testtoken" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+}
+
+func TestDo_BodySetsContentType(t *testing.T) {
+	var gotCT, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, _ = c.Do(context.Background(), httpjson.Request{
+		Method: http.MethodPost,
+		URL:    srv.URL,
+		Body:   map[string]string{"key": "val"},
+	})
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q", gotCT)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q", gotMethod)
+	}
+}
+
+func TestDoJSON_DecodesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"name":"lurker","version":2}`))
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	var out struct {
+		Name    string `json:"name"`
+		Version int    `json:"version"`
+	}
+	if err := c.DoJSON(context.Background(), httpjson.Request{URL: srv.URL}, &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Name != "lurker" || out.Version != 2 {
+		t.Errorf("decoded = %+v", out)
+	}
+}
+
+func TestDoJSON_NilOut_SkipsDecode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not valid json at all !!!`))
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	if err := c.DoJSON(context.Background(), httpjson.Request{URL: srv.URL}, nil); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDo_DefaultMethod_IsGET(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Method
+	}))
+	defer srv.Close()
+
+	c := &httpjson.Client{HTTP: srv.Client()}
+	_, _ = c.Do(context.Background(), httpjson.Request{URL: srv.URL})
+	if got != http.MethodGet {
+		t.Errorf("method = %q, want GET", got)
+	}
+}
+
+func isErrorAs(err error, target **httpjson.Error) bool {
+	return errors.As(err, target)
+}

--- a/updates/lifecycle_test.go
+++ b/updates/lifecycle_test.go
@@ -28,7 +28,7 @@ func TestNewAppliesDefaults(t *testing.T) {
 	if c.cfg.Platform.OS != "linux" || c.cfg.Platform.Architecture != "amd64" {
 		t.Errorf("Platform default = %+v", c.cfg.Platform)
 	}
-	if c.client == nil || c.logger == nil {
+	if c.hjc == nil || c.hjc.HTTP == nil || c.logger == nil {
 		t.Fatal("client / logger should be defaulted")
 	}
 }

--- a/updates/updates.go
+++ b/updates/updates.go
@@ -63,7 +63,6 @@ type Status struct {
 // Checker polls registry metadata and keeps last status in memory.
 type Checker struct {
 	cfg    Config
-	client *http.Client
 	hjc    *httpjson.Client
 	logger *slog.Logger
 
@@ -103,7 +102,6 @@ func New(cfg Config) *Checker {
 
 	c := &Checker{
 		cfg:    cfg,
-		client: cfg.Client,
 		hjc:    &httpjson.Client{HTTP: cfg.Client},
 		logger: cfg.Logger,
 	}

--- a/updates/updates.go
+++ b/updates/updates.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/lepinkainen/lurker/internal/httpjson"
 )
 
 // Config controls periodic remote image metadata checks.
@@ -62,6 +64,7 @@ type Status struct {
 type Checker struct {
 	cfg    Config
 	client *http.Client
+	hjc    *httpjson.Client
 	logger *slog.Logger
 
 	mu                sync.RWMutex
@@ -98,7 +101,12 @@ func New(cfg Config) *Checker {
 		cfg.Logger = slog.Default()
 	}
 
-	c := &Checker{cfg: cfg, client: cfg.Client, logger: cfg.Logger}
+	c := &Checker{
+		cfg:    cfg,
+		client: cfg.Client,
+		hjc:    &httpjson.Client{HTTP: cfg.Client},
+		logger: cfg.Logger,
+	}
 	c.status = Status{
 		Enabled:          cfg.Enabled,
 		Image:            cfg.Image,
@@ -149,7 +157,7 @@ func (c *Checker) run(ctx context.Context) {
 
 func (c *Checker) check(ctx context.Context) {
 	st := c.Status()
-	remote, err := fetchRemoteStatus(ctx, c.client, c.cfg)
+	remote, err := fetchRemoteStatus(ctx, c.hjc, c.cfg)
 	st.CheckedAt = time.Now().UTC()
 	if err != nil {
 		st.Error = err.Error()
@@ -226,17 +234,17 @@ const (
 	mediaTypeDockerManifestV2   = "application/vnd.docker.distribution.manifest.v2+json"
 )
 
-func fetchRemoteStatus(ctx context.Context, client *http.Client, cfg Config) (remoteStatus, error) {
+func fetchRemoteStatus(ctx context.Context, hjc *httpjson.Client, cfg Config) (remoteStatus, error) {
 	repo, err := normalizeImage(cfg.Image)
 	if err != nil {
 		return remoteStatus{}, err
 	}
-	token, err := registryToken(ctx, client, cfg, repo)
+	token, err := registryToken(ctx, hjc, cfg, repo)
 	if err != nil {
 		return remoteStatus{}, err
 	}
 	manifestURL := fmt.Sprintf("https://ghcr.io/v2/%s/manifests/%s", repo, cfg.Tag)
-	body, digest, mediaType, err := getRegistryJSON(ctx, client, manifestURL, token)
+	body, digest, mediaType, err := getRegistryJSON(ctx, hjc, manifestURL, token)
 	if err != nil {
 		return remoteStatus{}, err
 	}
@@ -254,7 +262,7 @@ func fetchRemoteStatus(ctx context.Context, client *http.Client, cfg Config) (re
 			return remoteStatus{}, fmt.Errorf("no manifest for %s/%s", cfg.Platform.OS, cfg.Platform.Architecture)
 		}
 		manifestURL = fmt.Sprintf("https://ghcr.io/v2/%s/manifests/%s", repo, entry.Digest)
-		manifestBody, manifestDigest, manifestMediaType, err = getRegistryJSON(ctx, client, manifestURL, token)
+		manifestBody, manifestDigest, manifestMediaType, err = getRegistryJSON(ctx, hjc, manifestURL, token)
 		if err != nil {
 			return remoteStatus{}, err
 		}
@@ -268,7 +276,7 @@ func fetchRemoteStatus(ctx context.Context, client *http.Client, cfg Config) (re
 		return remoteStatus{}, fmt.Errorf("decode manifest: %w", unmarshalErr)
 	}
 	configURL := fmt.Sprintf("https://ghcr.io/v2/%s/blobs/%s", repo, manifest.Config.Digest)
-	configBody, _, _, err := getRegistryJSON(ctx, client, configURL, token)
+	configBody, _, _, err := getRegistryJSON(ctx, hjc, configURL, token)
 	if err != nil {
 		return remoteStatus{}, err
 	}
@@ -286,27 +294,27 @@ func fetchRemoteStatus(ctx context.Context, client *http.Client, cfg Config) (re
 	}, nil
 }
 
-func registryToken(ctx context.Context, client *http.Client, cfg Config, repo string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://ghcr.io/v2/%s/manifests/%s", repo, cfg.Tag), http.NoBody)
-	if err != nil {
-		return "", err
-	}
-	addAccept(req)
+func registryToken(ctx context.Context, hjc *httpjson.Client, cfg Config, repo string) (string, error) {
+	var auth string
 	if cfg.Username != "" && cfg.Token != "" {
-		req.Header.Set("Authorization", basicAuth(cfg.Username, cfg.Token))
+		auth = basicAuth(cfg.Username, cfg.Token)
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("registry probe: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode == http.StatusOK {
+	_, err := hjc.Do(ctx, httpjson.Request{
+		URL:           fmt.Sprintf("https://ghcr.io/v2/%s/manifests/%s", repo, cfg.Tag),
+		Header:        registryAcceptHeader(),
+		Authorization: auth,
+	})
+	if err == nil {
 		return "", nil
 	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		return "", fmt.Errorf("registry probe: unexpected status %s", resp.Status)
+	var herr *httpjson.Error
+	if !errors.As(err, &herr) {
+		return "", fmt.Errorf("registry probe: %w", err)
 	}
-	challenge, err := parseChallenge(resp.Header.Get("Www-Authenticate"))
+	if herr.Status != http.StatusUnauthorized {
+		return "", fmt.Errorf("registry probe: unexpected status %d", herr.Status)
+	}
+	challenge, err := parseChallenge(herr.Header.Get("Www-Authenticate"))
 	if err != nil {
 		return "", err
 	}
@@ -314,26 +322,14 @@ func registryToken(ctx context.Context, client *http.Client, cfg Config, repo st
 		challenge.Scope = "repository:" + repo + ":pull"
 	}
 	tokenURL := fmt.Sprintf("%s?service=%s&scope=%s", challenge.Realm, challenge.Service, challenge.Scope)
-	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, http.NoBody)
-	if err != nil {
-		return "", err
-	}
-	if cfg.Username != "" && cfg.Token != "" {
-		tokenReq.Header.Set("Authorization", basicAuth(cfg.Username, cfg.Token))
-	}
-	resp, err = client.Do(tokenReq)
-	if err != nil {
-		return "", fmt.Errorf("registry token request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("registry token request: unexpected status %s", resp.Status)
-	}
 	var payload struct {
 		Token string `json:"token"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("decode registry token: %w", err)
+	if err := hjc.DoJSON(ctx, httpjson.Request{
+		URL:           tokenURL,
+		Authorization: auth,
+	}, &payload); err != nil {
+		return "", fmt.Errorf("registry token request: %w", err)
 	}
 	return payload.Token, nil
 }
@@ -364,39 +360,31 @@ func (c *Checker) logError(err error) {
 	c.logger.Warn("update check failed", "image", c.cfg.Image, "tag", c.cfg.Tag, "err", err)
 }
 
-func getRegistryJSON(ctx context.Context, client *http.Client, url, token string) (body []byte, digest string, mediaType string, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
-	if err != nil {
-		return nil, "", "", err
-	}
-	addAccept(req)
+func getRegistryJSON(ctx context.Context, hjc *httpjson.Client, url, token string) (body []byte, digest string, mediaType string, err error) {
+	var auth string
 	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+		auth = "Bearer " + token
 	}
-	resp, err := client.Do(req)
+	resp, err := hjc.Do(ctx, httpjson.Request{
+		URL:           url,
+		Header:        registryAcceptHeader(),
+		Authorization: auth,
+	})
 	if err != nil {
-		return nil, "", "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, "", "", fmt.Errorf("registry request %s: unexpected status %s", url, resp.Status)
-	}
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, "", "", fmt.Errorf("read registry response: %w", err)
+		return nil, "", "", fmt.Errorf("registry request %s: %w", url, err)
 	}
 	mediaType = strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])
-	return body, resp.Header.Get("Docker-Content-Digest"), mediaType, nil
+	return resp.Body, resp.Header.Get("Docker-Content-Digest"), mediaType, nil
 }
 
-func addAccept(req *http.Request) {
-	req.Header.Set("Accept", strings.Join([]string{
+func registryAcceptHeader() http.Header {
+	return http.Header{"Accept": []string{strings.Join([]string{
 		mediaTypeOCIImageIndex,
 		mediaTypeDockerManifestList,
 		mediaTypeOCIImageManifest,
 		mediaTypeDockerManifestV2,
 		"application/json",
-	}, ", "))
+	}, ", ")}}
 }
 
 func parseChallenge(header string) (authChallenge, error) {


### PR DESCRIPTION
## Summary

- New `internal/httpjson` package with `Client.Do` (raw response + headers) and `Client.DoJSON` (decode into typed output). Default 4 MiB body cap; error body truncated at 2 KiB; default `Accept: application/json` with caller override.
- `datasource/bluesky`: `doJSON` delegates to `hjc.DoJSON`; local `httpError` replaced by `httpjson.Error`; XRPC error code parse stays local.
- `updates`: `getRegistryJSON` and `registryToken` use `hjc.Do`/`hjc.DoJSON`; gains a body cap that was previously absent.
- `cmd/tui`: `fetchState` replaced with `hjc.DoJSON`.
- `preview/youtube` and `preview/fediverse` deferred — both ~15 lines dropping all errors, SSRF-guarded client injection makes migration non-trivial with little value gain.

Closes #60

## Test plan

- [ ] `task test` — all packages pass including new `internal/httpjson` unit tests
- [ ] `task lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)